### PR TITLE
Proper Author Metadata

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,7 +19,6 @@ baseurl: "/wai-website" # the subpath of your site, e.g. /blog
 url: "https://w3c.github.io" # the base hostname & protocol for your site
 twitter:
   username: w3c_wai
-author: w3c_wai
 exclude:
   - "_external"
   - "Gemfile"


### PR DESCRIPTION
When using a service like https://zbib.org for citation, the author metadata set on the WAI web pages is `w3c_wai` instead of `W3C Web Accessibility Initiative`, probably because of the duplicated `author:` line that this pull request removes.