### PR TITLE
Add assets link for wcag-act-rules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -217,6 +217,7 @@
 [submodule "_external/resources/wcag-act-rules"]
 	path = _external/resources/wcag-act-rules
 	url = https://github.com/w3c/wcag-act-rules.git
+    branch = steve-fix-testcases
 [submodule "_external/resources/wai-curricula"]
 	path = _external/resources/wai-curricula
 	url = https://github.com/w3c/wai-curricula.git

--- a/assets/wcag-act-rules
+++ b/assets/wcag-act-rules
@@ -1,1 +1,0 @@
-../_external/resources/wcag-act-rules/assets/wcag-act-rules/

--- a/assets/wcag-act-rules
+++ b/assets/wcag-act-rules
@@ -1,0 +1,1 @@
+../_external/resources/wcag-act-rules/assets/wcag-act-rules/

--- a/content-assets/wcag-act-rules
+++ b/content-assets/wcag-act-rules
@@ -1,0 +1,1 @@
+../_external/resources/wcag-act-rules/content-assets/wcag-act-rules/


### PR DESCRIPTION
Act rules need to add a lot of files unprocessed by Jekyll.
This mirrors conntent-images and provides content-assets.