### PR TITLE
Use “news” template for news

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -188,7 +188,7 @@ defaults:
   - scope:
       path: "_posts"
     values:
-      layout: "default"
+      layout: "news"
   - scope:
       path: "_audiences"
     values:


### PR DESCRIPTION
I have no idea why this is defaulting to default. Probably a heat-of-the-moment copy and paste error.

Please test before merging as I have no way to test locally.