### PR TITLE
Excludes APG Landmark Examples Pages from site search

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -378,6 +378,22 @@ tipue_search:
         "patterns",
         "apg-examples"
       ]
+  exclude:
+    files:
+      [
+        "pages/wai-aria-practices/patterns/landmarks/examples/HTML5.html",
+        "pages/wai-aria-practices/patterns/landmarks/examples/at.html",
+        "pages/wai-aria-practices/patterns/landmarks/examples/banner.html",
+        "pages/wai-aria-practices/patterns/landmarks/examples/complementary.html",
+        "pages/wai-aria-practices/patterns/landmarks/examples/contentinfo.html",
+        "pages/wai-aria-practices/patterns/landmarks/examples/form.html",
+        "pages/wai-aria-practices/patterns/landmarks/examples/general-principles.html",
+        "pages/wai-aria-practices/patterns/landmarks/examples/main.html",
+        "pages/wai-aria-practices/patterns/landmarks/examples/navigation.html",
+        "pages/wai-aria-practices/patterns/landmarks/examples/region.html",
+        "pages/wai-aria-practices/patterns/landmarks/examples/resources.html",
+        "pages/wai-aria-practices/patterns/landmarks/examples/search.html",
+      ]
 
 # TODO docs say don't need to declare any used in the Theme
 plugins:


### PR DESCRIPTION
Fixes #357 by excluding the following pages from the site search:

* https://www.w3.org/WAI/ARIA/apg/patterns/landmarks/examples/general-principles.html
* https://www.w3.org/WAI/ARIA/apg/patterns/landmarks/examples/HTML5.html
* https://www.w3.org/WAI/ARIA/apg/patterns/landmarks/examples/banner.html
* https://www.w3.org/WAI/ARIA/apg/patterns/landmarks/examples/complementary.html
* https://www.w3.org/WAI/ARIA/apg/patterns/landmarks/examples/contentinfo.html
* https://www.w3.org/WAI/ARIA/apg/patterns/landmarks/examples/form.html
* https://www.w3.org/WAI/ARIA/apg/patterns/landmarks/examples/main.html
* https://www.w3.org/WAI/ARIA/apg/patterns/landmarks/examples/navigation.html
* https://www.w3.org/WAI/ARIA/apg/patterns/landmarks/examples/region.html
* https://www.w3.org/WAI/ARIA/apg/patterns/landmarks/examples/search.html
* https://www.w3.org/WAI/ARIA/apg/patterns/landmarks/examples/at.html
* https://www.w3.org/WAI/ARIA/apg/patterns/landmarks/examples/resources.html

I followed [jekyll-tipue-search's README](https://github.com/jekylltools/jekyll-tipue-search#excluding-from-search-index) on doing the exclusions.

@shawna-slh please let me know if how the paths to the files are defined is okay. I verified locally with my `wai-website` build that all 12 pages are excluded from the site search.