### PR TITLE
Pin bundler version to `v2.4.22` on workflow runs

### DIFF
--- a/.github/workflows/build-only.yml
+++ b/.github/workflows/build-only.yml
@@ -28,7 +28,7 @@ jobs:
 #        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Build and test with Jekyll
       run: |
-        gem install bundler
+        gem install bundler -v '2.4.22'
         bundle install --jobs 4 --retry 3
         bundle exec jekyll build --verbose --trace --config "_config.yml,_config_prod.yml" --profile
 # Only works for pushes to PRs and that is not useful for our approach.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Build and test with Jekyll
       run: |
         export WAI_LIVE_SITE=true
-        gem install bundler
+        gem install bundler -v '2.4.22'
         bundle install --jobs 4 --retry 3
         bundle exec jekyll build --config "_config.yml,_config_prod.yml" --profile
 # Only works for pushes to PRs and that is not useful for our approach.


### PR DESCRIPTION
Bundler has recently released [`v2.5+` which has dropped support for ruby 2.6 (and 2.7)](https://github.com/rubygems/rubygems/releases/tag/bundler-v2.5.0), which this repository's build process uses, so that has been a source of recent deployment failures.

The last supported version of bundler which can work with ruby 2.6.x is `v2.4.22`. This PR pins that dependency for the relevant workflow files (`deploy.yml` and `build-only.yml`).

Also verified this change with my own fork by running [build-only](https://github.com/howard-e/wai-website/actions/runs/7277541284/job/19829769182).