### PR TITLE
Change news date format on homepage

### DIFF
--- a/index.md
+++ b/index.md
@@ -58,7 +58,7 @@ inline_css: |
         {%- for post in site.posts -%}
           <article class="news-teaser">
               <h3>{%comment%}<a href="{{ post.url | relative_url }}">{%endcomment%}{{post.title}}{%comment%}</a>{%endcomment%}</h3>
-              <p><small>({{post.date | date: "%Y-%m-%d"}})</small></p>
+              <p><small>({{post.date | date: "%Y-%b-%d"}})</small></p>
               {{ post.content | markdownify }}
           </article>
           {%- if forloop.index == 7 -%}


### PR DESCRIPTION
- https://github.com/w3c/wai-news/pull/70 changed the date format on [All News list](https://www.w3.org/WAI/news/)
- https://github.com/w3c/wai-website-theme/pull/74 added the date when browsing a particular news post
- This PR changes the date format on the homepage