### PR TITLE
Update workflows

### DIFF
--- a/.github/workflows/build-only.yml
+++ b/.github/workflows/build-only.yml
@@ -8,8 +8,11 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: write
+
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - name: Set up Ruby 2.6
@@ -20,13 +23,6 @@ jobs:
     - name: Update Externals
       run: |
         git submodule update --init --remote
-#    - name: Commit changed files
-#      uses: stefanzweifel/git-auto-commit-action@v2.1.0
-#      with:
-#        commit_message: Apply automatic changes
-#        branch: master
-#      env:
-#        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Build and test with Jekyll
       run: |
         bundle exec jekyll build --verbose --trace --config "_config.yml,_config_prod.yml" --profile
@@ -41,49 +37,3 @@ jobs:
     - name: check output
       run: |
         ls -la _site
-#    - name: Publish to gh-pages
-#      uses: peaceiris/actions-gh-pages@v3
-#      with:
-#        github_token: ${{ secrets.GITHUB_TOKEN }}
-#        publish_dir: _site
-#    - name: Zip Files
-#      uses: montudor/action-zip@v0.1.0
-#      with:
-#        args: zip -r build.zip ./_site
-#    - name: Upload zip file to release
-#      uses: svenstaro/upload-release-action@v1-release
-#      with:
-#        repo_token: ${{ secrets.GITHUB_TOKEN }}
-#        file: build.zip
-#        asset_name: build.zip
-#        tag: ${{ github.ref }}
-#        overwrite: true
-#    - name: Wait for gh-pages to be updated
-#      uses: jakejarvis/wait-action@master
-#      with:
-#        time: '30s'
-#    - name: Update URL mapping on W3C site
-#      uses: fjogeleit/http-request-action@master
-#      with:
-#        url: 'https://www.w3.org/services/update-wai-map'
-#        method: 'POST'
-#        timeout: 30000
-    # - name: Check Links
-    #   uses: peter-evans/link-checker@v1.0.0
-    #   with:
-    #     args: -v -d https://www.w3.org/ -r _site
-    # - name: Upload link check report to release
-    #   uses: svenstaro/upload-release-action@v1-release
-    #   with:
-    #     repo_token: ${{ secrets.GITHUB_TOKEN }}
-    #     file: ./link-checker/out.md
-    #     asset_name: link-report.md
-    #     tag: ${{ github.ref }}
-    #     overwrite: true
-    # - name: Create Issue From File
-    #   uses: peter-evans/create-issue-from-file@v1.0.1
-    #   env:
-    #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    #     ISSUE_TITLE: Link Checker Report
-    #     ISSUE_CONTENT_FILEPATH: ./link-checker/out.md
-    #     ISSUE_LABELS: report, automated issue

--- a/.github/workflows/build-only.yml
+++ b/.github/workflows/build-only.yml
@@ -15,6 +15,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
+        fetch-depth: 0
     - name: Set up Ruby 2.6
       uses: ruby/setup-ruby@v1
       with:

--- a/.github/workflows/build-only.yml
+++ b/.github/workflows/build-only.yml
@@ -16,6 +16,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.6.2
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
     - name: Update Externals
       run: |
         git submodule update --init --remote
@@ -28,8 +29,6 @@ jobs:
 #        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Build and test with Jekyll
       run: |
-        gem install bundler -v '2.4.22'
-        bundle install --jobs 4 --retry 3
         bundle exec jekyll build --verbose --trace --config "_config.yml,_config_prod.yml" --profile
 # Only works for pushes to PRs and that is not useful for our approach.
 #    - name: calibreapp/image-actions

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,15 +3,17 @@ name: Deploy
 on:
   release:
     types: [created]
-  
 
 jobs:
   build:
 
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: write
+
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - name: Set up Ruby 2.6.2
@@ -23,12 +25,10 @@ jobs:
       run: |
         git submodule update --remote
     - name: Commit changed files
-      uses: stefanzweifel/git-auto-commit-action@v2.1.0
+      uses: stefanzweifel/git-auto-commit-action@v5
       with:
         commit_message: Apply automatic changes
         branch: master
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Build and test with Jekyll
       run: |
         export WAI_LIVE_SITE=true
@@ -42,16 +42,16 @@ jobs:
       run: |
         find ./_site -type f | sed 's,^\.\/_site,,' | sort > ./_site/manifest.txt
     - name: Publish to gh-pages
-      uses: peaceiris/actions-gh-pages@v3
+      uses: peaceiris/actions-gh-pages@v4
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: _site
     - name: Zip Files
-      uses: montudor/action-zip@v0.1.0
+      uses: montudor/action-zip@v1
       with:
         args: zip -r build.zip ./_site
     - name: Upload zip file to release
-      uses: svenstaro/upload-release-action@v1-release
+      uses: svenstaro/upload-release-action@v2
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
         file: build.zip
@@ -62,27 +62,8 @@ jobs:
       run: sleep 90s
       shell: bash
     - name: Update URL mapping on W3C site
-      uses: fjogeleit/http-request-action@master
+      uses: fjogeleit/http-request-action@v1
       with:
         url: 'https://www.w3.org/services/update-wai-map'
         method: 'POST'
         timeout: 70000
-    # - name: Check Links
-    #   uses: peter-evans/link-checker@v1.0.0
-    #   with:
-    #     args: -v -d https://www.w3.org/ -r _site
-    # - name: Upload link check report to release
-    #   uses: svenstaro/upload-release-action@v1-release
-    #   with:
-    #     repo_token: ${{ secrets.GITHUB_TOKEN }}
-    #     file: ./link-checker/out.md
-    #     asset_name: link-report.md
-    #     tag: ${{ github.ref }}
-    #     overwrite: true
-    # - name: Create Issue From File
-    #   uses: peter-evans/create-issue-from-file@v1.0.1
-    #   env:
-    #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    #     ISSUE_TITLE: Link Checker Report
-    #     ISSUE_CONTENT_FILEPATH: ./link-checker/out.md
-    #     ISSUE_LABELS: report, automated issue

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
+        fetch-depth: 0
     - name: Set up Ruby 2.6.2
       uses: ruby/setup-ruby@v1
       with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: '2.6.2' # matches Netlify of ruby version
-#        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
     - name: Update Externals
       run: |
         git submodule update --remote
@@ -32,8 +32,6 @@ jobs:
     - name: Build and test with Jekyll
       run: |
         export WAI_LIVE_SITE=true
-        gem install bundler -v '2.4.22'
-        bundle install --jobs 4 --retry 3
         bundle exec jekyll build --config "_config.yml,_config_prod.yml" --profile
 # Only works for pushes to PRs and that is not useful for our approach.
 #    - name: calibreapp/image-actions

--- a/.github/workflows/mapsite.yml
+++ b/.github/workflows/mapsite.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
     - name: Update URL mapping on W3C site
-      uses: fjogeleit/http-request-action@master
+      uses: fjogeleit/http-request-action@v1
       with:
         url: 'https://www.w3.org/services/update-wai-map'
         method: 'POST'

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Check confirmation
       run: |
         test "yes" == "${{ github.event.inputs.areYouSure }}"
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         ref: gh-pages
         fetch-depth: 10
@@ -31,7 +31,7 @@ jobs:
         git reset --hard ${{ github.event.inputs.targetRef }}
         git push -f
     - name: Update URL mapping on W3C site
-      uses: fjogeleit/http-request-action@master
+      uses: fjogeleit/http-request-action@v1
       with:
         url: 'https://www.w3.org/services/update-wai-map'
         method: 'POST'


### PR DESCRIPTION
- Cache Ruby Gems to speed up installing gems during deploys. See [Caching bundle install automatically
](https://github.com/ruby/setup-ruby?tab=readme-ov-file#caching-bundle-install-automatically)
- Update actions
- Remove lines commented out