### PR TITLE
Set default "github.repository" attribute for collection pages.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -41,7 +41,7 @@ repository: w3c/wai-website
 ytkey: AIzaSyCiZ9uToWu9jb7BTx47NtzCvmGGXKXp8nI
 
 # remote_themes are an extension for Jekyll running in GitHub pages and are a GitHub repo 
-remote_theme: w3c/wai-website-theme
+remote_theme: w3c/wai-website-theme@github-file-path
 
 paginate: 5
 paginate_path: "/news/:num/"
@@ -52,21 +52,18 @@ collections:
     area: "Accessibility Fundamentals"
     name: "Web Accessibility Perspective Videos"
     shortname: "Perspective Videos"
-    repository: w3c/wai-perspective-videos
     output: true
     acknowledgements: true
     permalink: /:collection/:path/
   people-use-web:
     area: "Accessibility Fundamentals"
     name: "How People with Disabilities Use the Web"
-    repository: w3c/wai-people-use-web
     output: true
     acknowledgements: false
     permalink: /:collection/:path/
   planning-and-managing:
     area: "Plan and Manage"
     name: "Planning and Managing"
-    repository: w3c/wai-dynamic-planning
     output: true
     acknowledgements: false
     permalink: /:collection/:path/
@@ -74,7 +71,6 @@ collections:
     area: "Teach & Advocate"
     name: "Accessibility Training"
     shortname: Trainings
-    repository: w3c/wai-develop-training
     output: true
     acknowledgements: false
     permalink: /teach-advocate/:collection/:path/
@@ -82,7 +78,6 @@ collections:
     area: "All Areas"
     name: "Tips for Getting Started"
     shortname: Getting Started Tips
-    repository: w3c/wai-quick-start
     output: true
     acknowledgements: false
     permalink: /:collection/:path/
@@ -91,7 +86,6 @@ collections:
     name: "Web Accessibility Laws & Policies"
     shortname: "Laws & Policies"
     parent: "/planning/"
-    repository: w3c/wai-policies-prototype
     output: true
     acknowledgements: false
     permalink: /:collection/:path/
@@ -103,7 +97,6 @@ collections:
     area: "Plan & Manage"
     name: "Older Users"
     shortname: "Older Users"
-    repository: w3c/wai-older-users
     output: true
     acknowledgements: false
     permalink: /:collection/:path/
@@ -112,7 +105,6 @@ collections:
     # area: "Plan & Manage"
     name: "Roles"
     shortname: "Roles"
-    repository: w3c/wai-audiences
     output: true
     acknowledgements: false
     permalink: /roles/:path/
@@ -120,7 +112,6 @@ collections:
     parent: "/"
   about:
     name: "About"
-    repository: w3c/wai-about-wai
     output: true
     acknowledgements: false
     permalink: /:collection/:path/
@@ -129,7 +120,6 @@ collections:
     output: true
     permalink: /news/:year-:month-:day/:title/
     parent: "/news/"
-    repository: "w3c/wai-news"
   patterns:
     title: Patterns
     permalink: WCAG2/supplemental/:collection/:name/

--- a/_config.yml
+++ b/_config.yml
@@ -41,7 +41,7 @@ repository: w3c/wai-website
 ytkey: AIzaSyCiZ9uToWu9jb7BTx47NtzCvmGGXKXp8nI
 
 # remote_themes are an extension for Jekyll running in GitHub pages and are a GitHub repo 
-remote_theme: w3c/wai-website-theme@github-file-path
+remote_theme: w3c/wai-website-theme
 
 paginate: 5
 paginate_path: "/news/:num/"

--- a/_config.yml
+++ b/_config.yml
@@ -161,42 +161,63 @@ defaults:
       path: "_perspective-videos"
     values:
       layout: "default"
+      github:
+        repository: w3c/wai-perspective-videos
   - scope:
       path: "_people-use-web"
     values:
       layout: "default"
+      github:
+        repository: w3c/wai-people-use-web
   - scope:
       path: "_planning-and-managing"
     values:
       layout: "default"
+      github:
+        repository: w3c/wai-dynamic-planning
   - scope:
       path: "_accessibility-training"
     values:
       layout: "default"
+      github:
+        repository: w3c/wai-develop-training
   - scope:
       path: "_tips"
     values:
       layout: "default"
+      github:
+        repository: w3c/wai-quick-start
   - scope:
       path: "_policies"
     values:
       layout: "policy"
+      github:
+        repository: w3c/wai-policies-prototype
   - scope:
       path: "_older-users"
     values:
       layout: "default"
+      github:
+        repository: w3c/wai-older-users
   - scope:
       path: "_about"
     values:
       layout: "default"
+      github:
+        repository: w3c/wai-about-wai
   - scope:
       path: "_posts"
     values:
       layout: "default"
+      github:
+        repository: w3c/wai-news
+        label: wai-news
   - scope:
       path: "_audiences"
     values:
       layout: "sidenav"
+      github:
+        repository: w3c/wai-audiences
   -
     scope: 
       type: "patterns"


### PR DESCRIPTION
For the "Fork & Edit" link, the path to the file in GitHub is constructed as follows: `https://github.com/{{repo}}/edit/{{branch}}/{{path}}`

This PR simplify how we set `repo` when a page is part of a collection. We now assign a default value to `github.repository` (an existing page attribute) to all pages in a collection folder, instead of using a redundant collection attribute (named `repository`). 

We achieve the same result, without maintaining a special case when a page is part of a collection.

Note: This will fix the "Fork & Edit link" in https://www.w3.org/WAI/perspective-videos/. See [preview](https://deploy-preview-476--wai-website.netlify.app/videos/standards-and-benefits/)