### PR TITLE
Accessibility Training – Topics – Fix link to Intro section

### DIFF
--- a/pages/teach-advocate/accessibility-training/topics.md
+++ b/pages/teach-advocate/accessibility-training/topics.md
@@ -51,7 +51,7 @@ This page provides material for web accessibility topics that you can use as bui
 <ul class="toc">
   <li><strong>Introducing Accessibility </strong>
      <ol>
-        <li><a href="#introduction">Introducing Web Accessibility</a></li>
+        <li><a href="#intro">Introducing Web Accessibility</a></li>
         <li><a href="#people">How People with Disabilities Use the Web</a></li>
         <li><a href="#components">Components of Web Accessibility</a><!--(sample presentation available) --></li>
         <li><a href="#promoting">Promoting Web Accessibility</a></li>


### PR DESCRIPTION
Fix issue raised by https://github.com/w3c/wai-develop-training/pull/35 & https://github.com/w3c/wai-develop-training/pull/9

Direct link to preview: https://deploy-preview-496--wai-website.netlify.app/teach-advocate/accessibility-training/topics/