### PR TITLE
Fix the description for aria-labelledby

### DIFF
--- a/pages/design-develop/tutorials/forms/labels.md
+++ b/pages/design-develop/tutorials/forms/labels.md
@@ -163,7 +163,7 @@ The `aria-label` attribute can also be used to identify form controls. This appr
 #### Using aria-labelledby
 {:.ap}
 
-The `aria-labelledby` attribute can also be used to identify form controls. This approach is well supported by screen readers and other assistive technology, but, unlike the `title` attribute (see below), the information is not conveyed to visual users. The approach should therefore only be used when the label of the control is clear from the surrounding content, like the button in the example below.
+The `aria-labelledby` attribute can also be used to identify form controls. This approach is well supported by screen readers and other assistive technology, like the `title` attribute (see below), the information is conveyed to visual users. The approach should therefore only be used when the label of the control is visually shown to the users either by a tooltip or visible text.
 
 The `id` of the element containing the label text is used as the value of the `aria-labelledby` attribute.
 


### PR DESCRIPTION
Re-creates @niwsa's [PR](https://github.com/w3c/wai-tutorials/pull/596) in `wai-tutorials` repository. 

Please read the [previous discussion](https://github.com/w3c/wai-tutorials/pull/596#issuecomment-559016964) before adding a review.

### Original description

Reference => https://www.w3.org/TR/wai-aria-1.1/#aria-label

aria-labelledby is used when content is visible either via tooltip or visible text.