### PR TITLE
Update designing: WCAG-links for "Use of color"

### DIFF
--- a/collections/_tips/designing.md
+++ b/collections/_tips/designing.md
@@ -223,6 +223,8 @@ While color can be useful to convey information, color should not be the only wa
 
 * **WCAG**
   * [Use of Color 1.4.1](/WAI/WCAG21/quickref/#use-of-color) ([Understanding 1.4.1](/WAI/WCAG21/Understanding/use-of-color))
+  * [Sensory Characteristics 1.3.3](/WAI/WCAG21/quickref/#sensory-characteristics) ([Understanding 1.3.3](/WAI/WCAG21/Understanding/sensory-characteristics.html))
+  * [Info and Relationships 1.3.1](/WAI/WCAG21/quickref/#info-and-relationships) ([Understanding 1.3.1](/WAI/WCAG21/Understanding/info-and-relationships))
 * **User Story**
   * [[Lexie, online shopper who cannot distinguish between certain colors (color blindness)]](/people-use-web/user-stories/story-four/)
 


### PR DESCRIPTION
Re-creates @JAWS-test2's https://github.com/w3c/wai-quick-start/pull/363

## Initial description

Fixes: https://github.com/w3c/wai-website/issues/729

Added 1.3.3 and 1.3.1
* 1.3.3, because the second example refers to it
* 1.3.1 because it concerns the color coding for AT users 