### PR TITLE
Null alt ref in Write meaningful text alternatives

### DIFF
--- a/collections/_tips/writing.md
+++ b/collections/_tips/writing.md
@@ -276,7 +276,7 @@ Write link text so that it describes the content of the link target. Avoid using
 
 ## Write meaningful text alternatives for images
 
-For every image, write alternative text that provides the information or function of the image. For purely decorative images, there is no need to write alternative text.
+For every image, write alternative text that provides the information or function of the image.  For purely decorative images that convey no information, do not provide alternative text.
 
 {::nomarkdown}
 {% include_cached box.html type="start" title="Example: Using alternative text to communicate important information" class="example" %}


### PR DESCRIPTION
Re-creates @bruce-usab's https://github.com/w3c/wai-quick-start/pull/378

## Initial description

This page is great!  But <q>no need to write alternative text</q> seems like an invitation to skip the alt attribute.  But how to convey <q>null alt</q> or the requirement that alternative text be <q>implemented in a way that it can be ignored by assistive technology</q> while using plain language?

Current:
> For purely decorative images, there is no need to write alternative text.

Proposed change:
> For purely decorative images that convey no information, do not provide alternative text.