### PR TITLE
Add Ken to other staff lists in about and about/update

### DIFF
--- a/pages/about/contacting.md
+++ b/pages/about/contacting.md
@@ -82,5 +82,6 @@ Comments on other parts of the W3C Web site (www.w3.org) go to: <site-comments@w
 * [Kevin White](https://www.w3.org/staff/#kevin) leads technical accessibility work, including oversight of accessibility Working Groups.
 * [Roy Ruoxi Ran](https://www.w3.org/staff/#ran) supports accessibility Working Groups and accessibility in China.
 * [Daniel Montalvo](https://www.w3.org/staff/#dmontalvo) supports accessibility Working Groups and standards harmonization in Europe.
+* [Ken Franqueiro](https://www.w3.org/staff/#kfranqueiro) develops the new technical architecture for WCAG 2, WCAG 3, and the WAI website.
 
 If you don't know who to contact, or to reach all WAI staff, you can e-mail <wai@w3.org>

--- a/pages/about/index.md
+++ b/pages/about/index.md
@@ -126,6 +126,7 @@ You can subscribe to get news announcements via e-mail, Atom/RSS feed, and socia
 * [Kevin White](https://www.w3.org/staff/#kevin) is Accessibility Technical Lead and supports the Accessibility Guidelines Working Group that develops Web Content Accessibility Guidelines (WCAG).
 * [Roy Ruoxi Ran (冉若曦)](https://www.w3.org/staff/#ran) supports accessibility Working Groups and accessibility in China.
 * [Daniel Montalvo](https://www.w3.org/staff/#dmontalvo) supports accessibility Working Groups and standards harmonization in Europe.
+* [Ken Franqueiro](https://www.w3.org/staff/#kfranqueiro) develops the new technical architecture for WCAG 2, WCAG 3, and the WAI website.
 
 To reach all WAI staff, you can e-mail <wai@w3.org>
 


### PR DESCRIPTION
This adds the equivalent of https://github.com/w3c/wai-about-wai/commit/87c91d12c2fbeed49cb2ddeed937a37f2a44b665 and https://github.com/w3c/wai-about-wai/commit/c424bba3561d6f457782e30fa18c2ff053f4a483, since their content was somehow missing from this repository.

`update.md` doesn't need changing, as https://github.com/w3c/wai-about-wai/commit/667c4b97973cdf3ae32a0eee7fb34b6eac122ffc seems to have been captured in this repo.