### PR TITLE
Add Ken to WAI-Core staff list

### DIFF
--- a/pages/about/projects/wai-core-2015/index.md
+++ b/pages/about/projects/wai-core-2015/index.md
@@ -65,5 +65,6 @@ For more information on the WAI-Core Project and other WAI work, see [Getting In
 The following W3C staff are supported in part by WAI-Core funds:
 
 *   [Shawn Lawton Henry](http://www.w3.org/People/Shawn/)
+*   [Ken Franqueiro](https://www.w3.org/staff/#kfranqueiro)
 *   Judy Brewer (through December 2022)
 *   Michael Cooper (through July 2023)


### PR DESCRIPTION
Adding to the section seen here: https://www.w3.org/WAI/about/projects/wai-core-2015/#project-staff

I added myself above the names who are no longer active staff, but feel free to move that down if it's meant to be strictly chronological by start date.