### PR TITLE
Update wcag2x-backlog.md link text

### DIFF
--- a/pages/about/groups/task-forces/wcag2x-backlog.md
+++ b/pages/about/groups/task-forces/wcag2x-backlog.md
@@ -11,7 +11,7 @@ lang: en
 
 The WCAG 2.x Backlog Task Force is a task force of the [Accessibility Guidelines Working Group (AG WG)](/about/groups/agwg/).
 
-Some information on this page is also shown on, and may be more current in, the [Mobile Accessibility Task Force page](https://www.w3.org/groups/tf/wcag2x-backlog/).
+Some information on this page is also shown on, and may be more current in, the [WCAG 2.x Backlog Task Force page](https://www.w3.org/groups/tf/wcag2x-backlog/).
 
 {::nomarkdown}
 {% include box.html type="end" %}


### PR DESCRIPTION
Page is great but "Mobile Accessibility Tassk Force" should be "WCAG 2.x Backlog Task Force".  The URL under the link text is correct.