### PR TITLE
Fix RESPECT Code of Practice link: use archived version

### DIFF
--- a/pages/planning-policies/involving-users.fr.md
+++ b/pages/planning-policies/involving-users.fr.md
@@ -19,9 +19,7 @@ github:
 permalink: /planning/involving-users/fr
 ref: /planning/involving-users/   # Do not change this
 
-changelog: /planning/involving-users/changelog/
 feedbackmail: wai@w3.org
-layout: default
 
 # In the footer below:
 # Do not translate or change CHANGELOG.
@@ -30,7 +28,7 @@ layout: default
 # Do not change the dates in the footer below.
 footer: >
   <p>Note à propos de l'audiodescription : la vidéo présente sur cette page n'inclut pas l'audiodescription synchronisée car les images n'illustrent que l'audio et ne fournissent pas d'informations supplémentaires. Dans ce cas-ci, l'audiodescription serait plus distrayante qu'utile pour la plupart des utilisateurs, y compris pour les personnes qui ne peuvent pas voir les images. La description des informations contenues dans les images est reprise dans la transcription textuelle avec description des visuels ("transcription descriptive").</p>
-  <p><strong>Date:</strong> Mise à jour : 9 janvier 2019. Ajout de la vidéo d'introduction : 28 avril 2020. Première publication : 9 décembre 2009. CHANGELOG.</p>
+  <p><strong>Date:</strong> Mise à jour : 9 janvier 2019. Ajout de la vidéo d'introduction : 28 avril 2020. Première publication : 9 décembre 2009.</p>
   <p><strong>Rédacteurs :</strong> <a hreflang="en" href="https://www.w3.org/People/Shawn/">Shawn Lawton Henry</a>, <a hreflang="en" href="https://www.w3.org/People/shadi/">Shadi Abou-Zahra</a>, et <a hreflang="en" href="https://www.w3.org/People/Andrew/">Andrew Arch</a>.</p>
   <p>Développé grâce aux éléments de l'<i lang="en">Education and Outreach Working Group</i> (<a hreflang="en" href="https://www.w3.org/WAI/EO/">EOWG</a>), avec le <a hreflang="en" href="https://www.w3.org/WAI/EO/2008/wai-age-tf">Groupe de Travail WAI-AGE</a>. Développé dans le cadre du <a hreflang="en" href="https://www.w3.org/WAI/WAI-AGE/">Projet WAI-AGE</a> financé par la Commission européenne au titre du 6e programme-cadre. Vidéo créée avec le soutien du projet <a hreflang="en" href="https://www.w3.org/WAI/about/projects/wai-guide/">WAI-Guide</a> financée par la Commission Européenne dans le cadre du programme Horizon 2020 (Accord de Subvention n°822245). <a hreflang="en" href="/WAI/test-evaluate/acknowledgements">Remerciements pour la vidéo</a>.</p>
 ---

--- a/pages/planning-policies/involving-users.fr.md
+++ b/pages/planning-policies/involving-users.fr.md
@@ -257,7 +257,7 @@ Suivez les bonnes pratiques pour travailler de manière formelle et informelle a
 
 Des ressources existent sur le Web pour vous guider en détail sur la manière de travailler avec des utilisateurs. Par exemple : [Interagir avec des personnes en situation de handicap (en anglais)](https://uiaccess.com/accessucd/interact.html),
 [Technologie d'assistance et choix du lieu (en anglais)](https://www.uiaccess.com/accessucd/involve.html#atloc),
-et [le code de conduite RESPECT (en anglais)](https://www.respectproject.org/code/charm.php?id=).
+et [le code de conduite RESPECT (en anglais)](https://web.archive.org/web/20220120174748/https://www.respectproject.org/code/charm_id.html).
 
 Alliez l'implication d'utilisateurs aux standards d'accessibilité
 ------------------------------------------------

--- a/pages/planning-policies/involving-users.md
+++ b/pages/planning-policies/involving-users.md
@@ -260,7 +260,7 @@ There are resources on the web that provide detailed guidance on working
 with users; for example, [Interacting with People with
 Disabilities](http://uiaccess.com/accessucd/interact.html),
 [Assistive Technology and Location](http://www.uiaccess.com/accessucd/involve.html#atloc),
-and [The RESPECT Code of Practice](http://www.respectproject.org/code/charm.php?id=).
+and [The RESPECT Code of Practice](https://web.archive.org/web/20220120174748/https://www.respectproject.org/code/charm_id.html).
 
 Combine User Involvement with Standards
 ------------------------------------------------

--- a/pages/planning-policies/involving-users.md
+++ b/pages/planning-policies/involving-users.md
@@ -21,10 +21,7 @@ github:
 permalink: /planning/involving-users/    # Add the language shortcode to the end, with no slash at end, for example: /link/to/page/fr
 ref: /planning/involving-users/   # Do not change this
 
-changelog: /planning/involving-users/changelog/ # Do not change this
-
 feedbackmail: wai@w3.org
-layout: default
 
 # In the footer below:
 # Do not change CHANGELOG and the dates
@@ -32,7 +29,7 @@ layout: default
 # Translate the Working Group and projects names. Leave the Working Group and projects acronyms in English.
 footer: >
   <p>Note about video description: The video on this page does not include synchronized audio description because the visuals only illustrate the audio and do not provide additional information. In this case, audio description would be more distracting than useful to most people, including people who cannot see the visuals. Description of visual information is integrated in the Text Transcript with Description of Visuals (“descriptive transcript”).</p>
-  <p><strong>Date:</strong> Main content updated 9 January 2019. Intro video added 28 April 2020. First published 9 December 2009. CHANGELOG.</p>
+  <p><strong>Date:</strong> Main content updated 9 January 2019. Intro video added 28 April 2020. First published 9 December 2009. </p>
   <p><strong>Editors:</strong> <a href="https://www.w3.org/People/Shawn/">Shawn Lawton Henry</a>, <a href="https://www.w3.org/People/shadi/">Shadi Abou-Zahra</a>, and <a href="https://www.w3.org/People/Andrew/">Andrew Arch</a>.</p>
   <p>Developed with input from the Education and Outreach Working Group (<a href="https://www.w3.org/WAI/EO/">EOWG</a>), with the <a href="https://www.w3.org/WAI/EO/2008/wai-age-tf.html">WAI-AGE Task Force</a>. Developed as part of the <a href="https://www.w3.org/WAI/WAI-AGE/">WAI-AGE Project</a> funded by the European Commission under the 6th Framework. Video developed with support from the <a href="https://www.w3.org/WAI/about/projects/wai-guide/">WAI-Guide</a> project funded by the European Commission (EC) under the Horizon 2020 program (Grant Agreement 822245). <a href="/WAI/test-evaluate/acknowledgements">Acknowledgments for video</a>.</p>
 ---


### PR DESCRIPTION
Resolves https://github.com/w3c/wai-website/issues/485$

Preview: https://deploy-preview-848--wai-website.netlify.app/planning/involving-users/#with

The link to the "RESPECT Code of Practice" is leading to a 404 (see https://www.w3.org/WAI/planning/involving-users/#with)

After quick investigation, the respectproject.org website no longer exists, and I could not found another version online, other than PDF.

I suggest to point to a web-archived version of the original page.

I have also deleted the link to changelog in the footer: there is none for now.