### PR TITLE
Name default branch "main"

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,7 +29,7 @@ jobs:
       uses: stefanzweifel/git-auto-commit-action@v5
       with:
         commit_message: Apply automatic changes
-        branch: master
+        branch: main
     - name: Build and test with Jekyll
       run: |
         export WAI_LIVE_SITE=true

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A Netlify preview is available at https://wai-website.netlify.app/
 
 ### The default branch name has changed. How to update my fork?
 
-Since @@ 2024, the default branch is named `main`, for consistency with other W3C repositories and [GitHub default branch name](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-branches#about-the-default-branch).
+Since 5 September 2024, the default branch is named `main`, for consistency with other W3C repositories and [GitHub default branch name](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-branches#about-the-default-branch).
 
 If you have an existing fork, you can [rename your fork's default branch](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch#renaming-a-branch).
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,6 @@ A Netlify preview is available at https://wai-website.netlify.app/
 
 Since @@ 2024, the default branch is named `main`, for consistency with other W3C repositories and [GitHub default branch name](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-branches#about-the-default-branch).
 
-If have an existing fork, you can [rename your fork's default branch](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch#renaming-a-branch).
+If you have an existing fork, you can [rename your fork's default branch](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch#renaming-a-branch).
 
 If you have a local clone, you can either delete and re-clone the repository, or update it by [running the commands from GitHub documentation](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch#updating-a-local-clone-after-a-branch-name-changes).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,21 @@
-# W3C WAI Website
+# Web Accessibility Initiative (WAI) Website
 
-- Live Website: https://www.w3.org/WAI/
-- Preview: https://wai-website.netlify.com/
+The [W3C Web Accessibility Initiative (WAI)](https://www.w3.org/WAI/) develops standards and support materials to help you understand and implement accessibility.
+
+This repository is used to develop content for the W3C WAI website.
+
+## Preview
 
 [![Netlify Status](https://api.netlify.com/api/v1/badges/faaa4954-0194-47fa-9b74-540ab79f4a8d/deploy-status)](https://app.netlify.com/sites/wai-website/deploys)
+
+A Netlify preview is available at https://wai-website.netlify.app/
+
+## FAQ
+
+### The default branch name has changed. How to update my fork?
+
+Since @@ 2024, the default branch is named `main`, for consistency with other W3C repositories and [GitHub default branch name](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-branches#about-the-default-branch).
+
+If have an existing fork, you can [rename your fork's default branch](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch#renaming-a-branch).
+
+If you have a local clone, you can either delete and re-clone the repository, or update it by [running the commands from GitHub documentation](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch#updating-a-local-clone-after-a-branch-name-changes).

--- a/_config.yml
+++ b/_config.yml
@@ -37,7 +37,7 @@ kramdown:
   syntax_highlighter: rouge
 highlighter: rouge
 repository: w3c/wai-website
-branch: master
+branch: main
 
 ytkey: AIzaSyBzq155tA3E3gaYlRdx2S9U9FM78U1-568
 

--- a/pages/design-develop/changelog.md
+++ b/pages/design-develop/changelog.md
@@ -22,7 +22,7 @@ footer: >
 {% include box.html type="start" title="About" class="" %}
 {:/}
 
-This page is designed so translators can copy and paste from this rendered changelog page. Or, translators can use the [Design and Develop Overview page source](https://raw.githubusercontent.com/w3c/wai-website/master/pages/wai-design-develop-overview/index.md).
+This page is designed so translators can copy and paste from this rendered changelog page. Or, translators can use the [Design and Develop Overview page source](https://raw.githubusercontent.com/w3c/wai-website/main/pages/wai-design-develop-overview/index.md).
 
 For others, **particularly significant or substantive changes are summarized after “Significant:”**.
 


### PR DESCRIPTION
For consistency: new GitHub repos use `main` as default branch name and most W3C repos now use `main`.

Description of this pull request:
- Add instructions for forked repositories/local clones in README
- Update GitHub Actions to properly commit changes from submodules.
- Update _config.yml to make "Fork & Edit" links work
- Update a link in "Design & Develop" changelog