### PR TITLE
Archive EOWG pages

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "_external/data"]
 	path = _external/data
 	url = https://github.com/w3c/wai-website-data.git
-	branch = master
+	branch = eowg-closed
 [submodule "_external/resources/wcag-act-rules"]
 	path = _external/resources/wcag-act-rules
 	url = https://github.com/w3c/wcag-act-rules.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "_external/data"]
 	path = _external/data
 	url = https://github.com/w3c/wai-website-data.git
-	branch = eowg-closed
+	branch = master
 [submodule "_external/resources/wcag-act-rules"]
 	path = _external/resources/wcag-act-rules
 	url = https://github.com/w3c/wcag-act-rules.git

--- a/pages/about/groups/archive/eowg.md
+++ b/pages/about/groups/archive/eowg.md
@@ -5,7 +5,12 @@ lang: en
 permalink: /about/groups/eowg/
 ref: /about/groups/eowg/
 github:
-    label: wai-groups
+  label: wai-groups
+doc-note-type: archived
+doc-note-message-md: |
+    The Education and Outreach Working Group (EOWG) was closed in September 2024.
+    
+    More information in [19 September 2024 blog post](https://www.w3.org/blog/2024/accessibility-education-and-outreach-another-milestone-in-w3cs-30-year-history-and-evolution/).
 ---
 
 {::nomarkdown}

--- a/pages/about/groups/archive/eowg/participants.md
+++ b/pages/about/groups/archive/eowg/participants.md
@@ -5,6 +5,11 @@ ref: /about/groups/eowg/participants/
 lang: en
 github:
   label: wai-groups
+doc-note-type: archived
+doc-note-message-md: |
+  The Education and Outreach Working Group (EOWG) was closed in September 2024.
+
+  More information in [19 September 2024 blog post](https://www.w3.org/blog/2024/accessibility-education-and-outreach-another-milestone-in-w3cs-30-year-history-and-evolution/).
 ---
 
 {::comment}

--- a/pages/about/groups/archive/eowg/participate.md
+++ b/pages/about/groups/archive/eowg/participate.md
@@ -5,6 +5,11 @@ ref: /about/groups/eowg/participate/
 lang: en
 github:
   label: wai-groups
+doc-note-type: archived
+doc-note-message-md: |
+  The Education and Outreach Working Group (EOWG) was closed in September 2024.
+
+  More information in [19 September 2024 blog post](https://www.w3.org/blog/2024/accessibility-education-and-outreach-another-milestone-in-w3cs-30-year-history-and-evolution/).
 ---
 
 {::nomarkdown}

--- a/pages/about/groups/index.md
+++ b/pages/about/groups/index.md
@@ -5,7 +5,7 @@ lang: en
 permalink: /about/groups/
 ref: /about/groups/
 github:
-    label: wai-groups
+  label: wai-groups
 ---
 
 WAI has Working Groups developing accessibility guidelines and related
@@ -17,42 +17,32 @@ linked below. WAI working groups often have Task Forces operating under
 them; see Task Force link below.
 
 [Accessibility Guidelines Working Group (AG WG)](/about/groups/agwg/) *(formerly WCAG WG)*
-:   AG WG develops guidelines to make web content accessible for people
-    with disabilities, and develops implementation support materials for
-    the Web Content Accessibility Guidelines.
+: AG WG develops guidelines to make web content accessible for people
+with disabilities, and develops implementation support materials for
+the Web Content Accessibility Guidelines.
 
 [Accessible Platform Architectures (APA)](/about/groups/apawg/)
-:   APA reviews specifications, develops technical support materials,
-    collaborates with other Working Groups on technology accessibility,
-    and coordinates harmonized accessibility strategies within W3C.
+: APA reviews specifications, develops technical support materials,
+collaborates with other Working Groups on technology accessibility,
+and coordinates harmonized accessibility strategies within W3C.
 
 [Accessible Rich Internet Applications (ARIA)](/about/groups/ariawg/)
-:   ARIA develops the Accessible Rich Internet Applications (WAI-ARIA)
-    suite of technologies and other technical specifications when needed
-    to bridge known gaps.
-
-[Education and Outreach Working Group (EOWG)](/about/groups/eowg/)
-:   EOWG develops awareness and training materials and education
-    resources on Web accessibility solutions .
+: ARIA develops the Accessible Rich Internet Applications (WAI-ARIA)
+suite of technologies and other technical specifications when needed
+to bridge known gaps.
 
 [WAI Interest Group (WAI IG)](/about/groups/waiig/)
-:   WAI IG is a public group with a mailing list for general discussion
-    on Web accessibility.
+: WAI IG is a public group with a mailing list for general discussion
+on Web accessibility.
 
 Previous Groups:
-
--   Authoring Tool Accessibility Working Group
-    ([AUWG](https://www.w3.org/WAI/AU/Overview.html))
--   Evaluation and Repair Tools Working Group ([ERT WG](https://www.w3.org/WAI/ER/Overview.html))
--   Research and Development Working Group ([RDWG](https://www.w3.org/WAI/RD/Overview.html))
--   User Agent Accessibility Working Group ([UAWG](https://www.w3.org/WAI/UA/Overview.html))
+- [Education and Outreach Working Group (EOWG)](/about/groups/eowg/)
+- Authoring Tool Accessibility Working Group ([AUWG](https://www.w3.org/WAI/AU/Overview.html))
+- Evaluation and Repair Tools Working Group ([ERT WG](https://www.w3.org/WAI/ER/Overview.html))
+- Research and Development Working Group ([RDWG](https://www.w3.org/WAI/RD/Overview.html))
+- User Agent Accessibility Working Group ([UAWG](https://www.w3.org/WAI/UA/Overview.html))
 
 See also:
 
--   [**Task Forces**](/about/groups/task-forces/) - Lists some active Task Forces that
-    operate under WAI Working Groups, and/or jointly between WAI groups
-    and other W3C groups.
--   **[Participating in WAI](/about/participating/)** - Describes participation
-    opportunities ranging from volunteering to implement, promote, and
-    review guidelines, to occasional participation in an interest group,
-    to dedicated participation in a working group.
+- [**Task Forces**](/about/groups/task-forces/) - Lists some active Task Forces that operate under WAI Working Groups, and/or jointly between WAI groups and other W3C groups.
+-   **[Participating in WAI](/about/participating/)** - Describes participation opportunities ranging from volunteering to implement, promote, and  review guidelines, to occasional participation in an interest group, to dedicated participation in a working group.

--- a/pages/about/index.md
+++ b/pages/about/index.md
@@ -7,8 +7,8 @@ feedbackmail: wai@w3.org
 class: tight-page
 github:
    label: wai-about
-footer: > # Text in footer in HTML
-  <p><strong>Date:</strong> Updated 13 March 2024.</p>
+footer: >
+  <p><strong>Date:</strong> Updated 3 October 2024.</p>
 ---
 
 {::nomarkdown}
@@ -140,7 +140,6 @@ WAI includes the following Working Groups and Interest Group:
 -   [Accessibility Guidelines Working Group (AG WG)](/about/groups/agwg/) (formerly the Web Content Accessibility Guidelines Working Group)
 -   [Accessible Platform Architectures (APA) Working Group](/about/groups/apawg/)
 -   [Accessible Rich Internet Applications (ARIA) Working Group](/about/groups/ariawg/)
--   [Education and Outreach Working Group (EOWG)](/about/groups/eowg/)
 -   [WAI Interest Group (WAI IG)](/about/groups/waiig/) is an e-mail discussion list that is open to anyone
 
 Within the Working Groups, there are also [Task Forces](/about/groups/task-forces/).

--- a/pages/about/participating.md
+++ b/pages/about/participating.md
@@ -10,7 +10,7 @@ github:
     label: wai-about
 
 footer: >
-  <p><strong>Date:</strong> Updated 29 April 2024.</p>
+  <p><strong>Date:</strong> Updated 3 October 2024.</p>
   <p><strong>Editor:</strong> <a href="http://www.w3.org/People/Shawn/">Shawn Lawton Henry</a>.</p>
   <p>Developed with the Education and Outreach Working Group (<a href="http://www.w3.org/WAI/EO/">EOWG</a>).</p>
 ---
@@ -104,7 +104,6 @@ including requirements for participation and contribution. See the
 Working Group pages below to find what group best fits your interests
 and to get information on participation.
 
--   **[EOWG](/WAI/EO)** &mdash; The Accessibility Education and Outreach Working Group develops awareness, training, and implementation resources supporting web accessibility. **See [Participating in EOWG](/WAI/EO/participation)**.
 -   **[AG WG](/WAI/GL)** &mdash; The Accessibility Guidelines Working Group develops guidelines for web pages, web applications, and other web content. **See [Participating in AG WG](/WAI/GL/participation)**.
 -   **[APA](/WAI/APA/)** &mdash; The Accessible Platform Architectures (APA) Working Group reviews W3C's specifications for accessibility support and develops technical support materials. **See [Participating in APA WG](/WAI/APA/participation)**.
 -   **[ARIA](/WAI/ARIA/)** &mdash; The Accessible Rich Internet Applications Working Group develops a suite of accessible rich internet applications (ARIA) resources, and accessible APIs and mappings. **See [Participating in ARIA WG](/WAI/ARIA/participation)**.


### PR DESCRIPTION
Resolves https://github.com/w3c/wai-website/issues/893

- [Groups page](https://deploy-preview-895--wai-website.netlify.app/about/groups/): Move EOWG link to "Previous groups":
- Archive EOWG pages:
  - [[Archived] Education and Outreach Working Group (EOWG)](https://deploy-preview-895--wai-website.netlify.app/about/groups/eowg/)
  - [[Archived] Participating in the Education and Outreach Working Group (EOWG)](https://deploy-preview-895--wai-website.netlify.app/about/groups/eowg/participate/)
  - [[Archived] Education and Outreach Working Group (EOWG) Participants](https://deploy-preview-895--wai-website.netlify.app/about/groups/eowg/participants)
- Update [“Participating”](https://deploy-preview-895--wai-website.netlify.app/about/participating/)
- Update [“About W3C WAI”](https://deploy-preview-895--wai-website.netlify.app/about/)