### PR TITLE
Add draft banner in Netlify previews

### DIFF
--- a/_config_staging.yml
+++ b/_config_staging.yml
@@ -1,4 +1,4 @@
 baseurl: "/" # the subpath of your site, e.g. /blog
 url: "https://wai-website.netlify.com" # the base hostname & protocol for your site
 warning_message: >
-  This is a draft preview of the W3C WAI website. The published website is at <a href="https://www.w3.org/WAI/">w3.org/WAI/</a>.
+  This is an unpublished draft preview that might include content that is not yet approved. The published website is at <a href="https://www.w3.org/WAI/">w3.org/WAI/</a>.

--- a/_config_staging.yml
+++ b/_config_staging.yml
@@ -1,3 +1,2 @@
 baseurl: "/" # the subpath of your site, e.g. /blog
 url: "https://wai-website.netlify.com" # the base hostname & protocol for your site
-published: true

--- a/_config_staging.yml
+++ b/_config_staging.yml
@@ -1,2 +1,4 @@
 baseurl: "/" # the subpath of your site, e.g. /blog
 url: "https://wai-website.netlify.com" # the base hostname & protocol for your site
+warning_message: >
+  This is a draft preview of the W3C WAI website. The published website is at <a href="https://www.w3.org/WAI/">w3.org/WAI/</a>.


### PR DESCRIPTION
The Netlify previews are missing a draft banner, to warn readers that they do not browse a stable/approved version of the WAI website.

This pull request puts back the banner and customizes the warning message.