### PR TITLE
EOWG: indicate “was closed in 2024” instead of “in September 2024”

### DIFF
--- a/pages/about/groups/archive/eowg.md
+++ b/pages/about/groups/archive/eowg.md
@@ -8,7 +8,7 @@ github:
   label: wai-groups
 doc-note-type: archived
 doc-note-message-md: |
-    The Education and Outreach Working Group (EOWG) was closed in September 2024.
+    The Education and Outreach Working Group (EOWG) was closed in 2024.
     
     More information in [19 September 2024 blog post](https://www.w3.org/blog/2024/accessibility-education-and-outreach-another-milestone-in-w3cs-30-year-history-and-evolution/).
 ---

--- a/pages/about/groups/archive/eowg/participants.md
+++ b/pages/about/groups/archive/eowg/participants.md
@@ -7,7 +7,7 @@ github:
   label: wai-groups
 doc-note-type: archived
 doc-note-message-md: |
-  The Education and Outreach Working Group (EOWG) was closed in September 2024.
+  The Education and Outreach Working Group (EOWG) was closed in 2024.
 
   More information in [19 September 2024 blog post](https://www.w3.org/blog/2024/accessibility-education-and-outreach-another-milestone-in-w3cs-30-year-history-and-evolution/).
 ---

--- a/pages/about/groups/archive/eowg/participate.md
+++ b/pages/about/groups/archive/eowg/participate.md
@@ -7,7 +7,7 @@ github:
   label: wai-groups
 doc-note-type: archived
 doc-note-message-md: |
-  The Education and Outreach Working Group (EOWG) was closed in September 2024.
+  The Education and Outreach Working Group (EOWG) was closed in 2024.
 
   More information in [19 September 2024 blog post](https://www.w3.org/blog/2024/accessibility-education-and-outreach-another-milestone-in-w3cs-30-year-history-and-evolution/).
 ---


### PR DESCRIPTION
As agreed with @shawna-slh 