### PR TITLE
Update contacting.md

### DIFF
--- a/pages/about/contacting.md
+++ b/pages/about/contacting.md
@@ -28,49 +28,49 @@ class: tight-page
 
 ## Press inquiries
 
-For press inquiries regarding accessibility or the Web Accessibility Initiative (WAI), please send email to [shawn@w3.org, w3t-pr@w3.org, wai@w3.org](mailto:shawn@w3.org,w3t-pr@w3.org,wai@w3.org?subject=press%20request-accessibility)
+For press inquiries regarding accessibility or the Web Accessibility Initiative (WAI), email [shawn@w3.org, w3t-pr@w3.org, wai@w3.org](mailto:shawn@w3.org,w3t-pr@w3.org,wai@w3.org?subject=press%20request-accessibility)
 
-For other W3C press inquiries, see [How to contact W3C, Press](/Consortium/Contact#press).
+For press inquiries regarding W3C, see [How to contact W3C, Press](/Consortium/Contact#press).
 
 ## Technical, implementation, and other support questions
 
 ### WAI website
 
-Many questions are addressed in documents on the WAI website.
-* A good starting place to find relevant resources is the [Accessibility Fundamentals Overview listing page](/fundamentals/) and [Introduction to Web Accessibility](/fundamentals/accessibility-intro/).
-* For information on Web Content Accessibility Guidelines (WCAG), see the [WCAG 2 Overview](/standards-guidelines/wcag/).
-* **For an annotated list of all WAI educational and technical support documents** covering a wide range of topics for content authors, designers, developers, evaluators, testers, managers, policy makers, trainers, educators, web users, advocates, and people with disabilities, see **[[WAI Resources]](/resources/)**.
+Many questions about web accessibility are addressed on the WAI website.
+* Good starting places to find relevant resources are [Accessibility Fundamentals Overview listing page](/fundamentals/), [Introduction to Web Accessibility](/fundamentals/accessibility-intro/) and [WAI resources](/resources/).
+* For information on the Web Content Accessibility Guidelines (WCAG), see the [WCAG 2 Overview](/standards-guidelines/wcag/).
 
-### Mailing list for questions
+### Mailing list for accessibility questions
 
-WAI hosts a WAI Interest Group (IG) mailing list for discussion of digital accessibility issues. The list is open for anyone to read, submit, and respond. If you have a question that might be relevant to the WAI IG list, you can:
+WAI hosts a WAI Interest Group (IG) mailing list for discussion of digital accessibility issues and questions. The list is open for anyone to read, submit, and respond to it. If you have a question that might be relevant to the WAI IG list, you can:
 
--   Search the [WAI IG mailing list archives](http://lists.w3.org/Archives/Public/w3c-wai-ig/) to see the topic has already been addressed sufficiently
--   Read the [Mailing Lists](/about/groups/waiig/#mailinglist) section of the WAI IG page for guidance on contributing to a comfortable, constructive exchange of ideas; <br>then [Subscribe to the Discussion List](/about/groups/waiig/#subscribing-and-unsubscribing-to-the-discussion-list) and post appropriate questions
+-   search the [WAI IG mailing list archives](http://lists.w3.org/Archives/Public/w3c-wai-ig/) to see if the topic of your question has already been addressed
+-   read the [Mailing Lists](/about/groups/waiig/#mailinglist) section of the WAI IG page for guidance on contributing to a comfortable, constructive exchange of ideas
+-  [subscribe to the Discussion List](/about/groups/waiig/#subscribing-and-unsubscribing-to-the-discussion-list) and post your questions.
 
 ## Feedback on specific documents
 
 To submit comments on a specific document:
 
--   Most WAI web pages have a 'Help improve this page' box near the bottom of the page with links to submit issues and change requests through GitHub, or by email.
--   For W3C guidelines, Notes, and Working Drafts that are under <code>www.w3.org/TR</code>, see 'Status of This Document' section for the email address and/or GitHub repository to send comments.
+-   Most WAI web pages have a 'Help improve this page' box near the bottom of the page, where you can find links to propose edits and submit issues through GitHub or by email.
+-   For [W3C guidelines](/standards-guidelines/), [Draft Notes](/standards/types/#x2-5-1-draft-note), and [Working Drafts](/standards/types/#x4-1-working-draft) that are under <code>www.w3.org/TR</code>, see the 'Status of This Document' section for the email address and/or GitHub repository to send comments.
 
-If you cannot determine where to send comments on a specific document, send a email to <a href="mailto:wai@w3.org?body=%5Binclude%20a%20relevant%20email%20Subject%5D%0A%0A%5Bput%20comment%20here...%5D%0A%0AI%20give%20permission%20to%20share%20this%20to%20a%20publicly-archived%20email%20list.">wai@w3.org</a> with the document name in the subject line and the permission to send your email to a publicly-archived email list. We will forward your message to the appropriate place.
+If you cannot determine where to send comments on a specific document, email <a href="mailto:wai@w3.org?body=%5Binclude%20a%20relevant%20email%20Subject%5D%0A%0A%5Bput%20comment%20here...%5D%0A%0AI%20give%20permission%20to%20share%20this%20to%20a%20publicly-archived%20email%20list.">wai@w3.org</a> with the document name in the subject line and the permission to send your email to a publicly-archived email list. We will forward your message to the appropriate place.
 
 ## Feedback on the WAI website design
 
-You can submit comments on the overall WAI Web site (www.w3.org/) either to a W3C WAI staff list or to a public list:
--   <team-site-design@w3.org> (for WAI staff, not public)
--   <wai-site-comments@w3.org> (can be seen by the public)
+You can submit comments on the overall WAI website (www.w3.org/) either to a W3C WAI staff list or to a public list:
+-   <team-site-design@w3.org> (seen by WAI staff only, not public)
+-   <wai-site-comments@w3.org> (seen by WAI staff and the public)
 
 ## WAI staff
 * [Shawn Lawton Henry](https://www.w3.org/staff/#shawn) is Web Accessibility Initiative (WAI) Program Lead; Accessibility Education and Communications Lead.
 * [Kevin White](https://www.w3.org/staff/#kevin) is Accessibility Technical Lead and supports the Accessibility Guidelines Working Group that develops Web Content Accessibility Guidelines (WCAG).
-* [Roy Ruoxi Ran (冉若曦)](https://www.w3.org/staff/#ran) supports accessibility Working Groups and accessibility in China.
-* [Daniel Montalvo](https://www.w3.org/staff/#dmontalvo) supports accessibility Working Groups and standards harmonization.
-* [Ken Franqueiro](https://www.w3.org/staff/#kfranqueiro) develops the new technical architecture for WCAG 2, WCAG 3, and the WAI website.
-* [Tamsin Ewing](https://www.w3.org/staff/#tamsin) supports accessibility communications, educational resources, and Working Group deliverables.
+* [Roy Ruoxi Ran (冉若曦)](https://www.w3.org/staff/#ran) is Web Accessibility Engineer and supports accessibility working groups and accessibility in China.
+* [Daniel Montalvo](https://www.w3.org/staff/#dmontalvo) is Accessibility Specialist and supports accessibility working groups and standards harmonization.
+* [Ken Franqueiro](https://www.w3.org/staff/#kfranqueiro) is Web Software Engineer and develops the new technical architecture for WCAG 2, WCAG 3, and the WAI website.
+* [Tamsin Ewing](https://www.w3.org/staff/#tamsin) is Accessibility Content Specialist and supports accessibility communications, educational resources, and working group deliverables.
 
-If you don't know who to contact, or to reach all WAI staff, you can email <wai@w3.org>.
+If you do not know who to contact or want to reach all WAI staff, email <wai@w3.org>.
 
-Note that we generally are not able to answer specific support questions. Please send those questions to the [WAI IG mailing list, per above](/about/contacting/#mailing-list-for-questions).
+Note that WAI is not resourced to support with specific answers or feedback on your accessibility questions. Please send those questions to the [WAI IG mailing list, per above](/about/contacting/#mailing-list-for-questions).


### PR DESCRIPTION
I like the extra detail but I think this would be better on the actual page (and reduce wording on the Contact WAI page:

Move to the top of the WAI resources page

For an annotated list of all WAI educational and technical support documents covering a wide range of topics for content authors, designers, developers, evaluators, testers, managers, policy makers, trainers, educators, web users, advocates, and people with disabilities, see [WAI Resources].