### PR TITLE
Do not mark "Accessibility Principles" translations outdated

### DIFF
--- a/pages/fundamentals/accessibility-principles/index.ar.md
+++ b/pages/fundamentals/accessibility-principles/index.ar.md
@@ -10,7 +10,6 @@ description: نبذة عن مبادئ متطلبات إمكانية الوصول
 
 translation:
   last_updated: 2023-12-06  # Put the date of this translation YYYY-MM-DD (with month in the middle)
-  status: outdated
 
 translators:
 - name: "محمد سليم"

--- a/pages/fundamentals/accessibility-principles/index.cs.md
+++ b/pages/fundamentals/accessibility-principles/index.cs.md
@@ -11,7 +11,6 @@ teaser_text: Stránka Zásady přístupnosti představuje některé požadavky n
 
 translation:
   last_updated: 2023-12-06   # Put the date of this translation YYYY-MM-DD (with month in the middle)
-  status: outdated
 
 translators: 
 - name: "Kristýna Švecová"

--- a/pages/fundamentals/accessibility-principles/index.es.md
+++ b/pages/fundamentals/accessibility-principles/index.es.md
@@ -11,7 +11,6 @@ teaser_text: La página de Principios de Accesibilidad introduce algunos de los 
 
 translation:
   last_updated: 2023-12-06   # Put the date of this translation YYYY-MM-DD (with month in the middle)
-  status: outdated
 
 translators:
 - name: "Jorge Rumoroso"

--- a/pages/fundamentals/accessibility-principles/index.fr.md
+++ b/pages/fundamentals/accessibility-principles/index.fr.md
@@ -10,7 +10,6 @@ teaser_text: La page «&#8239;Principes d’accessibilité&#8239;» présente ce
 
 translation:
   last_updated: 2023-12-06  # Put the date of this translation YYYY-MM-DD (with month in the middle)
-  status: outdated
 
 translators:
 - name: "Stéphane Deschamps"

--- a/pages/fundamentals/accessibility-principles/index.ja.md
+++ b/pages/fundamentals/accessibility-principles/index.ja.md
@@ -11,7 +11,6 @@ teaser_text: アクセシビリティ原則のページでは、ウェブサイ�
 
 translation:
   last_updated: 2023-12-06
-  status: outdated
 
 translators: 
 - name: "Takumi Ishihara"   # Replace @@ with translator name

--- a/pages/fundamentals/accessibility-principles/index.ko.md
+++ b/pages/fundamentals/accessibility-principles/index.ko.md
@@ -11,7 +11,6 @@ teaser_text: 접근성 원칙 페이지는 웹 사이트, 웹 어플리케이션
 
 translation:
   last_updated: 2023-12-06  # Put the date of this translation YYYY-MM-DD (with month in the middle)
-  status: outdated
 
 translators: 
 - name: "Yong Ui Lee"   # Replace @@ with translator name

--- a/pages/fundamentals/accessibility-principles/index.ru.md
+++ b/pages/fundamentals/accessibility-principles/index.ru.md
@@ -11,7 +11,6 @@ teaser_text: The Accessibility Principles page introduces some of the web access
 
 translation:
   last_updated: 2023-12-06  # Put the date of this translation YYYY-MM-DD (with month in the middle)
-  status: outdated
 
 translators: 
 - name: "Daniel Novichkov"

--- a/pages/fundamentals/accessibility-principles/index.zh-hans.md
+++ b/pages/fundamentals/accessibility-principles/index.zh-hans.md
@@ -11,7 +11,6 @@ teaser_text: 无障碍原则页面介绍了网站、web应用程序、浏览器�
 
 translation:
   last_updated: 2023-12-06  # Put the date of this translation YYYY-MM-DD (with month in the middle)
-  status: outdated
 
 translators: 
 - name: "李松峰"   # Replace @@ with translator name


### PR DESCRIPTION
I am considering not marking the current "Accessibility Principles" translations outdated.

The last update consisted in referring to the new User stories (https://www.w3.org/WAI/fundamentals/accessibility-principles/changelog/#july-2024). This update has not affected the meaning or the intentions of the resource. Therefore, the current versions of the translations stay relevant and a disclaimer seems excessive.

That being said, we welcome contributions to update the existing translations. An issue is tracking this: https://github.com/w3c/wai-translations/issues/266