### PR TITLE
Update translation sitemaps list

### DIFF
--- a/collections/_translations-sitemaps/sitemap-pt-br.md
+++ b/collections/_translations-sitemaps/sitemap-pt-br.md
@@ -1,0 +1,8 @@
+---
+title: "Brazilian Portuguese Translations Progress"
+nav_title: Brazilian Portuguese Translations Progress
+tlang: pt-BR
+
+permalink: /about/translating/sitemaps/sitemap-pt-br/
+ref: /about/translating/sitemaps/sitemap-pt-br/
+---

--- a/collections/_translations-sitemaps/sitemap-ru.md
+++ b/collections/_translations-sitemaps/sitemap-ru.md
@@ -1,8 +1,0 @@
----
-title: "Russian Translations Progress"
-nav_title: Russian Translations Progress
-tlang: ru
-
-permalink: /about/translating/sitemaps/sitemap-ru/
-ref: /about/translating/sitemaps/sitemap-ru/
----


### PR DESCRIPTION
Add Brazilian Portuguese translation sitemap (new active volunteers) and remove Russian translation sitemap (no active volunteers for now).