### PR TITLE
wai-website-data: target main branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "_external/data"]
 	path = _external/data
 	url = https://github.com/w3c/wai-website-data.git
-	branch = master
+	branch = main
 [submodule "_external/resources/wcag-act-rules"]
 	path = _external/resources/wcag-act-rules
 	url = https://github.com/w3c/wcag-act-rules.git


### PR DESCRIPTION
> [!WARNING]
> Do not merge this PR before renaming the branch in wai-website-data repository.

This pull request updates `.gitmodules` to target the `main` branch of `wai-website-data` submodule (instead of the `master` branch).

Rationale: new GitHub repos use `main` as default branch name and most W3C repos now use `main`.