### PR TITLE
Outdate translations of 'WCAG 2 Overview'

### DIFF
--- a/pages/standards-guidelines/wcag/index.es.md
+++ b/pages/standards-guidelines/wcag/index.es.md
@@ -9,6 +9,7 @@ last_updated: 2024-03-07  # Keep the date of the English version
 description: Introduce el estándar internacional de las Pautas de Accesibilidad para el Contenido Web (WCAG), lo cual incluye WCAG 2.0, WCAG 2.1 y WCAG 2.2. Los documentos de las WCAG explican cómo hacer contenido web más accesible para las personas con discapacidad.
 
 translation:
+  status: outdated
   last_updated: 2024-05-01  # Put the date of this translation YYYY-MM-DD (with month in the middle)
 
 translators: 

--- a/pages/standards-guidelines/wcag/index.fr.md
+++ b/pages/standards-guidelines/wcag/index.fr.md
@@ -8,6 +8,7 @@ lang: fr
 last_updated: 2024-03-07  # Keep the date of the English version
 
 translation:
+  status: outdated
   last_updated: 2024-04-09 # Put the date of this translation YYYY-MM-DD (with month in the middle)
 
 description: Présente le standard international des Règles pour l’accessibilité des contenus web (WCAG), notamment WCAG 2.0, WCAG 2.1 et WCAG 2.2. Les documents des WCAG expliquent comment rendre les contenus Web plus accessibles aux personnes en situation de handicap.

--- a/pages/standards-guidelines/wcag/index.ja.md
+++ b/pages/standards-guidelines/wcag/index.ja.md
@@ -9,6 +9,7 @@ last_updated: 2024-03-07  # Keep the date of the English version
 description: WCAG2.0、WCAG2.1、WCAG2.2を含む、国際標準のウェブコンテンツアクセシビリティガイドライン（WCAG）を紹介。WCAG文書は、ウェブコンテンツを障害がある人にとってよりアクセシブルにする方法を説明しています。
 
 translation:
+  status: outdated
   last_updated: 2024-04-05  # Put the date of this translation YYYY-MM-DD (with month in the middle)
 
 translators: # remove from the beginning of this line and the lines below: "# " (the hash sign and the space)

--- a/pages/standards-guidelines/wcag/index.pl.md
+++ b/pages/standards-guidelines/wcag/index.pl.md
@@ -9,6 +9,7 @@ last_updated: 2024-03-07  # Keep the date of the English version
 description: Przedstawia międzynarodowy standard Wytyczne dla dostępności treści internetowych (Web Content Accessibility Guidelines, WCAG), w tym WCAG 2.0, WCAG 2.1 i WCAG 2.2. Dokumenty WCAG wyjaśniają, jak uczynić treści internetowe bardziej dostępnymi dla osób z niepełnosprawnościami.
 
 translation:
+  status: outdated
   last_updated: 2024-08-07  # Put the date of this translation YYYY-MM-DD (with month in the middle)
 
 translators:


### PR DESCRIPTION
'WCAG 2 Overview" has been extensively updated, following WCAG 2.1 and WCAG 2.2 updates: https://github.com/w3c/wai-website/pull/1009

This PR outdates the existing translations.