### PR TITLE
WAI Resources: Add Research section under Accessibility Fundamentals

### DIFF
--- a/pages/resources.md
+++ b/pages/resources.md
@@ -1,7 +1,7 @@
 ---
 title: WAI Resources
 lang: en
-last_updated: 2024-08-26
+last_updated: 2025-01-13
 
 github:
   label: wai-resources-list
@@ -86,6 +86,10 @@ The following resources provide information for **getting started with accessibi
 
 [[Accessibility Principles]](/fundamentals/accessibility-principles/)
 :   A concise introduction to accessibility requirements for websites, apps, browsers, and other tools. It is organized similar to the WAI accessibility standards and provides a useful bridge to the standards. Read this page before reading the standards/guidelines.
+
+Research:
+:   -   [[Accessibility User Requirements]](/research/user-requirements/) - Documentation of research on user needs in virtual or immersive environments (XR), real-time communication (RTC), natural language interfaces, multimedia, low vision, cognitive accessibility, and more.
+    -   [[Artificial Intelligence (AI) and Accessibility Research Symposium 2023]](/research/ai2023/) - Summaries, transcripts, and videos of the international symposium exploring the positive and negative impacts of artificial intelligence (AI) in digital accessibility.
 
 Digital Accessibility Courses:
 :   -   [[Digital Accessibility Foundations &mdash; Free Online Course]](/courses/foundations-course/) - Introduces a self-paced course from W3C WAI for developers, designers, ux, writers, managers, advocates. **Designed for technical and non-technical learners**, including students, instructors, professionals, and people with disabilities. Course is free with optional certificate.


### PR DESCRIPTION
This mirrors the items under "Research:" on the Accessibility Fundamentals page into the WAI Resources page.