### PR TITLE
Fix a markup error in wcag3-intro.ja.md

### DIFF
--- a/pages/standards-guidelines/wcag/wcag3-intro.ja.md
+++ b/pages/standards-guidelines/wcag/wcag3-intro.ja.md
@@ -90,7 +90,7 @@ WCAG 3のドラフト作成が進展に合わせて、このページを定期�
 * <span lang="en">Refining</span>（改良中）
 * <span lang="en">Mature</span>（成熟）
 
-これらのステータス指標の詳細については、解説セクション「[<span lang="en>Current Process for Creating WCAG 3.0</span>（現在の WCAG 3.0 作成プロセス）](https://www.w3.org/TR/2024/DNOTE-wcag-3.0-explainer-20241212/#current-process)を参照してください。
+これらのステータス指標の詳細については、解説セクション「[<span lang="en">Current Process for Creating WCAG 3.0</span>（現在の WCAG 3.0 作成プロセス）](https://www.w3.org/TR/2024/DNOTE-wcag-3.0-explainer-20241212/#current-process)を参照してください。
 
 ### ご意見募集
 


### PR DESCRIPTION
This PR fixes unintended rendering results caused by the markup error contained in the `wcag3-intro.ja.md`.

![スクリーンショット 2025-02-11 23 30 49](https://github.com/user-attachments/assets/3c045201-96a1-44d7-95eb-294cd143b078)
