### PR TITLE
Fix https// typos

### DIFF
--- a/pages/fundamentals/accessibility-principles/index.ar.md
+++ b/pages/fundamentals/accessibility-principles/index.ar.md
@@ -31,7 +31,7 @@ image: /content-images/accessibility-principles/social.png
 # Translate the Working Group name. Leave the Working Group acronym in English.
 footer: >
   <p><strong>المحررون:</strong> <a href="https://www.w3.org/People/shadi/">Shadi Abou Zahra</a>. <a href="https://www.w3.org/WAI/intro/people-use-web/acknowledgments"> شكر وتقدير </a>.</p>
-  <p> تم تطويره بمساهمة فريق التعليم و التوعية (<a href="https//www.w3.org/WAI/EO/">EOWG</a>). طور سابقا من قبل <a href="https://www.w3.org/WAI/EO/2008/wai-age-tf">WAI-AGE فريق</a>, بمساعدة<a href="https://www.w3.org/WAI/WAI-AGE/">WAI-AGE مشروع</a>.</p>
+  <p> تم تطويره بمساهمة فريق التعليم و التوعية (<a href="https://www.w3.org/WAI/EO/">EOWG</a>). طور سابقا من قبل <a href="https://www.w3.org/WAI/EO/2008/wai-age-tf">WAI-AGE فريق</a>, بمساعدة<a href="https://www.w3.org/WAI/WAI-AGE/">WAI-AGE مشروع</a>.</p>
 ---
  
 {::nomarkdown}

--- a/pages/fundamentals/accessibility-principles/index.cs.md
+++ b/pages/fundamentals/accessibility-principles/index.cs.md
@@ -30,7 +30,7 @@ image: /content-images/accessibility-principles/social.png
 # Translate the Working Group name. Leave the Working Group acronym in English.
 footer: >
   <p><strong>Editoři:</strong> <a href="https://www.w3.org/People/shadi/">Shadi Abou Zahra</a>. <a href="https://www.w3.org/WAI/intro/people-use-web/acknowledgments">Poděkování</a>.</p>
-  <p>Vyvinuto Pracovní skupinou pro vzdělání a osvětu (<a href="https//www.w3.org/WAI/EO/">EOWG</a>). Dříve vyvinuto s Pracovní skupinou <a href="https://www.w3.org/WAI/EO/2008/wai-age-tf">WAI-AGE</a> za podpory Projektu <a href="https://www.w3.org/WAI/WAI-AGE/">WAI-AGE</a>.</p>
+  <p>Vyvinuto Pracovní skupinou pro vzdělání a osvětu (<a href="https://www.w3.org/WAI/EO/">EOWG</a>). Dříve vyvinuto s Pracovní skupinou <a href="https://www.w3.org/WAI/EO/2008/wai-age-tf">WAI-AGE</a> za podpory Projektu <a href="https://www.w3.org/WAI/WAI-AGE/">WAI-AGE</a>.</p>
 ---
 
 {::nomarkdown}

--- a/pages/fundamentals/accessibility-principles/index.es.md
+++ b/pages/fundamentals/accessibility-principles/index.es.md
@@ -33,7 +33,7 @@ changelog: /fundamentals/accessibility-principles/changelog/   # Do not change t
 # Translate the Working Group name. Leave the Working Group acronym in English.
 footer: >
   <p><strong>Editores:</strong> <a href="https://www.w3.org/People/shadi/">Shadi Abou_Zahra</a>. <a href="https://www.w3.org/WAI/intro/people-use-web/acknowledgments">Agradecimientos</a>.</p>
-  <p>Desarrollado por el Grupo de Trabajo de Educación y Divulgación (<a href="https//www.w3.org/WAI/EO/">EOWG</a>). Previamente desarrollado con la <a href="https://www.w3.org/WAI/EO/2008/wai-age-tf">WAI-AGE Task Force</a>, con el apoyo del <a href="https://www.w3.org/WAI/WAI-AGE/">Proyecto WAI-AGE </a>.</p>
+  <p>Desarrollado por el Grupo de Trabajo de Educación y Divulgación (<a href="https://www.w3.org/WAI/EO/">EOWG</a>). Previamente desarrollado con la <a href="https://www.w3.org/WAI/EO/2008/wai-age-tf">WAI-AGE Task Force</a>, con el apoyo del <a href="https://www.w3.org/WAI/WAI-AGE/">Proyecto WAI-AGE </a>.</p>
 ---
 
 {::nomarkdown}

--- a/pages/fundamentals/accessibility-principles/index.fr.md
+++ b/pages/fundamentals/accessibility-principles/index.fr.md
@@ -30,7 +30,7 @@ image: /content-images/accessibility-principles/social.png
 # Translate the Working Group name. Leave the Working Group acronym in English.
 footer: >
   <p lang="en"><strong>Editors:</strong> <a href="https://www.w3.org/People/shadi/" hreflang="en">Shadi Abou Zahra</a>. <a href="https://www.w3.org/WAI/intro/people-use-web/acknowledgments" hreflang="en">Acknowledgments</a>.</p>
-  <p lang="en">Developed by the Education and Outreach Working Group (<a href="https//www.w3.org/WAI/EO/" hreflang="en">EOWG</a>). Previously developed with the <a href="https://www.w3.org/WAI/EO/2008/wai-age-tf" hreflang="en">WAI-AGE Task Force</a>, with support of the <a href="https://www.w3.org/WAI/WAI-AGE/" hreflang="en">WAI-AGE Project</a>.</p>
+  <p lang="en">Developed by the Education and Outreach Working Group (<a href="https://www.w3.org/WAI/EO/" hreflang="en">EOWG</a>). Previously developed with the <a href="https://www.w3.org/WAI/EO/2008/wai-age-tf" hreflang="en">WAI-AGE Task Force</a>, with support of the <a href="https://www.w3.org/WAI/WAI-AGE/" hreflang="en">WAI-AGE Project</a>.</p>
 ---
 
 {::nomarkdown}
@@ -123,7 +123,7 @@ Les alternatives textuelles peuvent être présentées sous des formes variées.
 **WCAG**
 
 -  [Guideline 1.1 - Text
-   Alternatives](https//www.w3.org/WAI/WCAG22/quickref/#text-equiv){: hreflang="en"}
+   Alternatives](https://www.w3.org/WAI/WCAG22/quickref/#text-equiv){: hreflang="en"}
 
 **UAAG**
 
@@ -195,7 +195,7 @@ Des retranscriptions texte bien écrites contenant la séquence correcte de tout
 **WCAG**
 
 -   [Guideline 1.2 - Time-based
-    Media](https//www.w3.org/WAI/WCAG22/quickref/#media-equiv)
+    Media](https://www.w3.org/WAI/WCAG22/quickref/#media-equiv)
 
 **UAAG**
 
@@ -260,7 +260,7 @@ Pour que les utilisateurs puissent changer la présentation des contenus, il est
 **WCAG**
 
 -   [Guideline 1.3 -
-    Adaptable](https//www.w3.org/WAI/WCAG22/quickref/#content-structure-separation)
+    Adaptable](https://www.w3.org/WAI/WCAG22/quickref/#content-structure-separation)
 
 **UAAG**
 
@@ -342,7 +342,7 @@ Un contenu perceptible est plus facile à lire et à voir. Par exemple&#8239;:
 **WCAG**
 
 -   [Guideline 1.4 -
-    Distinguishable](https//www.w3.org/WAI/WCAG22/quickref/#visual-audio-contrast)
+    Distinguishable](https://www.w3.org/WAI/WCAG22/quickref/#visual-audio-contrast)
 
 **UAAG**
 
@@ -423,7 +423,7 @@ L’accessibilité au clavier comprend&#8239;:
 **WCAG**
 
 -   [Guideline 2.1 - Keyboard
-    accessible](https//www.w3.org/WAI/WCAG22/quickref/#keyboard-operation)
+    accessible](https://www.w3.org/WAI/WCAG22/quickref/#keyboard-operation)
 
 **UAAG**
 
@@ -490,7 +490,7 @@ Là où il faut fournir assez de temps, cela implique de fournir des mécanismes
 **WCAG**
 
 -   [Guideline 2.2 - Enough
-    time](https//www.w3.org/WAI/WCAG22/quickref/#time-limits)
+    time](https://www.w3.org/WAI/WCAG22/quickref/#time-limits)
 
 **UAAG**
 
@@ -554,7 +554,7 @@ Comment éviter de provoquer des crises ou des réactions physiques&#8239;:
 **WCAG**
 
 -   [Guideline 2.3 -
-    Seizures](https//www.w3.org/WAI/WCAG22/quickref/#seizure)
+    Seizures](https://www.w3.org/WAI/WCAG22/quickref/#seizure)
 
 **UAAG**
 
@@ -606,7 +606,7 @@ Un contenu bien organisé permet aux utilisateurs de s’orienter et de naviguer
 **WCAG**
 
 -   [Guideline 2.4 -
-    Navigable](https//www.w3.org/WAI/WCAG22/quickref/#navigation-mechanisms)
+    Navigable](https://www.w3.org/WAI/WCAG22/quickref/#navigation-mechanisms)
 
 **UAAG**
 
@@ -732,7 +732,7 @@ Les auteurs de contenus doivent s’assurer que le contenu textuel est lisible e
 **WCAG**
 
 -   [Guideline 3.1 -
-    Readable](https//www.w3.org/WAI/WCAG22/quickref/#meaning)
+    Readable](https://www.w3.org/WAI/WCAG22/quickref/#meaning)
 
 **ATAG**
 
@@ -790,7 +790,7 @@ Un grand nombre de personnes s’appuie sur des interfaces prévisibles et est d
 **WCAG**
 
 -   [Guideline 3.2 -
-    Predictable](https//www.w3.org/WAI/WCAG22/quickref/#consistent-behavior)
+    Predictable](https://www.w3.org/WAI/WCAG22/quickref/#consistent-behavior)
 
 **UAAG**
 
@@ -857,7 +857,7 @@ Les formulaires et d’autres systèmes interactifs peuvent induire de la confus
 **WCAG**
 
 -   [Guideline 3.3 - Input
-    assistance](https//www.w3.org/WAI/WCAG22/quickref/#minimize-error)
+    assistance](https://www.w3.org/WAI/WCAG22/quickref/#minimize-error)
 
 **UAAG**
 
@@ -924,7 +924,7 @@ Un contenu robuste est compatible avec de multiples navigateurs, outils d’assi
 **WCAG**
 
 -   [Guideline 4.1 -
-    Compatible](https//www.w3.org/WAI/WCAG22/quickref/#ensure-compat)
+    Compatible](https://www.w3.org/WAI/WCAG22/quickref/#ensure-compat)
 
 **UAAG**
 

--- a/pages/fundamentals/accessibility-principles/index.ko.md
+++ b/pages/fundamentals/accessibility-principles/index.ko.md
@@ -32,7 +32,7 @@ image: /content-images/accessibility-principles/social.png
 # Translate the Working Group name. Leave the Working Group acronym in English.
 footer: >
   <p><strong>편집자:</strong> <a href="https://www.w3.org/People/shadi/">Shadi Abou_Zahra</a>. <a href="https://www.w3.org/WAI/intro/people-use-web/acknowledgments">Acknowledgments</a>.</p>
-  <p>교육과 활동관련 실무 그룹인 (<a href="https//www.w3.org/WAI/EO/">EOWG</a>)의 지원을 받아 제작되었습니다. <a href="https://www.w3.org/WAI/EO/2008/wai-age-tf">WAI-AGE Task Force</a>, with support of the <a href="https://www.w3.org/WAI/WAI-AGE/">WAI-AGE 프로젝트</a>의 지원과 <a href="https://www.w3.org/WAI/EO/2008/wai-age-tf">WAI-AGE 팀</a>에 의해 제작되었습니다.</p>
+  <p>교육과 활동관련 실무 그룹인 (<a href="https://www.w3.org/WAI/EO/">EOWG</a>)의 지원을 받아 제작되었습니다. <a href="https://www.w3.org/WAI/EO/2008/wai-age-tf">WAI-AGE Task Force</a>, with support of the <a href="https://www.w3.org/WAI/WAI-AGE/">WAI-AGE 프로젝트</a>의 지원과 <a href="https://www.w3.org/WAI/EO/2008/wai-age-tf">WAI-AGE 팀</a>에 의해 제작되었습니다.</p>
 ---
 
 {::nomarkdown}

--- a/pages/fundamentals/accessibility-principles/index.md
+++ b/pages/fundamentals/accessibility-principles/index.md
@@ -30,7 +30,7 @@ image: /content-images/accessibility-principles/social.png
 # Translate the Working Group name. Leave the Working Group acronym in English.
 footer: >
   <p><strong>Editors:</strong> <a href="https://www.w3.org/People/shadi/">Shadi Abou Zahra</a>. <a href="https://www.w3.org/WAI/intro/people-use-web/acknowledgments">Acknowledgments</a>.</p>
-  <p>Developed by the Education and Outreach Working Group (<a href="https//www.w3.org/WAI/EO/">EOWG</a>). Previously developed with the <a href="https://www.w3.org/WAI/EO/2008/wai-age-tf">WAI-AGE Task Force</a>, with support of the <a href="https://www.w3.org/WAI/WAI-AGE/">WAI-AGE Project</a>.</p>
+  <p>Developed by the Education and Outreach Working Group (<a href="https://www.w3.org/WAI/EO/">EOWG</a>). Previously developed with the <a href="https://www.w3.org/WAI/EO/2008/wai-age-tf">WAI-AGE Task Force</a>, with support of the <a href="https://www.w3.org/WAI/WAI-AGE/">WAI-AGE Project</a>.</p>
 ---
 
 {::nomarkdown}

--- a/pages/fundamentals/accessibility-principles/index.ru.md
+++ b/pages/fundamentals/accessibility-principles/index.ru.md
@@ -30,7 +30,7 @@ changelog: /fundamentals/accessibility-principles/changelog/   # Do not change t
 # Translate the Working Group name. Leave the Working Group acronym in English.
 footer: >
   <p><strong>Редакторы:</strong> <a href="https://www.w3.org/People/shadi/">Shadi Abou Zahra</a>. <a href="https://www.w3.org/WAI/intro/people-use-web/acknowledgments">Благодарности</a>.</p>
-  <p>Разработано Education and Outreach Working Group (<a href="https//www.w3.org/WAI/EO/">EOWG</a>). Ранее разработано <a href="https://www.w3.org/WAI/EO/2008/wai-age-tf">WAI-AGE Task Force</a>, при поддержке <a href="https://www.w3.org/WAI/WAI-AGE/">WAI-AGE Project</a>.</p>
+  <p>Разработано Education and Outreach Working Group (<a href="https://www.w3.org/WAI/EO/">EOWG</a>). Ранее разработано <a href="https://www.w3.org/WAI/EO/2008/wai-age-tf">WAI-AGE Task Force</a>, при поддержке <a href="https://www.w3.org/WAI/WAI-AGE/">WAI-AGE Project</a>.</p>
 ---
 
 {::nomarkdown}

--- a/pages/fundamentals/accessibility-principles/index.zh-hans.md
+++ b/pages/fundamentals/accessibility-principles/index.zh-hans.md
@@ -33,7 +33,7 @@ changelog: /fundamentals/accessibility-principles/changelog/   # Do not change t
 # Translate the Working Group name. Leave the Working Group acronym in English.
 footer: >
   <p><strong>编者：</strong> <a href="https://www.w3.org/People/shadi/">Shadi Abou_Zahra</a>. <a href="https://www.w3.org/WAI/intro/people-use-web/acknowledgments">致谢</a>.</p>
-  <p>由教育及外展工作组(<a href="https//www.w3.org/WAI/EO/">EOWG</a>)开发. 之前该网页受 <a href="https://www.w3.org/WAI/EO/2008/wai-age-tf">WAI-AGE 特别任务团</a>和<a href="https://www.w3.org/WAI/WAI-AGE/">WAI-AGE项目</a>的支持.</p>
+  <p>由教育及外展工作组(<a href="https://www.w3.org/WAI/EO/">EOWG</a>)开发. 之前该网页受 <a href="https://www.w3.org/WAI/EO/2008/wai-age-tf">WAI-AGE 特别任务团</a>和<a href="https://www.w3.org/WAI/WAI-AGE/">WAI-AGE项目</a>的支持.</p>
 ---
 
 {::nomarkdown}

--- a/pages/fundamentals/people/people-use-web/abilities-barriers/auditory.md
+++ b/pages/fundamentals/people/people-use-web/abilities-barriers/auditory.md
@@ -44,7 +44,7 @@ acknowledgements: /people-use-web/acknowledgements/ # Do not change this
 footer: >
   <p>Note about video description: The video on this page does not include synchronized audio description because the visuals only illustrate the audio and do not provide additional information. In this case, audio description would be more distracting than useful to most people, including people who cannot see the visuals. Description of visual information is available in the Text Transcript with Description of Visuals (“descriptive transcript”).</p>
   <p><strong>Editor:</strong> Shadi Abou-Zahra. Previous editor: Judy Brewer. Contributors listed in ACKNOWLEDGEMENTS.</p>
-  <p>Developed by the Education and Outreach Working Group (<a href="https//www.w3.org/WAI/EO/">EOWG</a>) with support from the <a href="https://www.w3.org/WAI/about/projects/wai-guide/">WAI-Guide Project</a> and <a href="https://www.w3.org/WAI/WAI-AGE/">WAI-AGE Project</a> co-funded by the European Commission (EC).</p>
+  <p>Developed by the Education and Outreach Working Group (<a href="https://www.w3.org/WAI/EO/">EOWG</a>) with support from the <a href="https://www.w3.org/WAI/about/projects/wai-guide/">WAI-Guide Project</a> and <a href="https://www.w3.org/WAI/WAI-AGE/">WAI-AGE Project</a> co-funded by the European Commission (EC).</p>
 ---
 {::nomarkdown}
 

--- a/pages/fundamentals/people/people-use-web/abilities-barriers/cognitive.md
+++ b/pages/fundamentals/people/people-use-web/abilities-barriers/cognitive.md
@@ -44,7 +44,7 @@ acknowledgements: /people-use-web/acknowledgements/ # Do not change this
 footer: >
   <p>Note about video description: The video on this page does not include synchronized audio description because the visuals only illustrate the audio and do not provide additional information. In this case, audio description would be more distracting than useful to most people, including people who cannot see the visuals. Description of visual information is available in the Text Transcript with Description of Visuals (“descriptive transcript”).</p>
   <p><strong>Editor:</strong> Shadi Abou-Zahra. Previous editor: Judy Brewer. Contributors listed in ACKNOWLEDGEMENTS.</p>
-  <p>Developed by the Education and Outreach Working Group (<a href="https//www.w3.org/WAI/EO/">EOWG</a>) with support from the <a href="https://www.w3.org/WAI/about/projects/wai-guide/">WAI-Guide Project</a> and <a href="https://www.w3.org/WAI/WAI-AGE/">WAI-AGE Project</a> co-funded by the European Commission (EC).</p>
+  <p>Developed by the Education and Outreach Working Group (<a href="https://www.w3.org/WAI/EO/">EOWG</a>) with support from the <a href="https://www.w3.org/WAI/about/projects/wai-guide/">WAI-Guide Project</a> and <a href="https://www.w3.org/WAI/WAI-AGE/">WAI-AGE Project</a> co-funded by the European Commission (EC).</p>
 ---
 
 {::nomarkdown}

--- a/pages/fundamentals/people/people-use-web/abilities-barriers/physical.md
+++ b/pages/fundamentals/people/people-use-web/abilities-barriers/physical.md
@@ -44,7 +44,7 @@ acknowledgements: /people-use-web/acknowledgements/ # Do not change this
 footer: >
   <p>Note about video description: The video on this page does not include synchronized audio description because the visuals only illustrate the audio and do not provide additional information. In this case, audio description would be more distracting than useful to most people, including people who cannot see the visuals. Description of visual information is available in the Text Transcript with Description of Visuals (“descriptive transcript”).</p>
   <p><strong>Editor:</strong> Shadi Abou-Zahra. Previous editor: Judy Brewer. Contributors listed in ACKNOWLEDGEMENTS.</p>
-  <p>Developed by the Education and Outreach Working Group (<a href="https//www.w3.org/WAI/EO/">EOWG</a>) with support from the <a href="https://www.w3.org/WAI/about/projects/wai-guide/">WAI-Guide Project</a> and <a href="https://www.w3.org/WAI/WAI-AGE/">WAI-AGE Project</a> co-funded by the European Commission (EC).</p>
+  <p>Developed by the Education and Outreach Working Group (<a href="https://www.w3.org/WAI/EO/">EOWG</a>) with support from the <a href="https://www.w3.org/WAI/about/projects/wai-guide/">WAI-Guide Project</a> and <a href="https://www.w3.org/WAI/WAI-AGE/">WAI-AGE Project</a> co-funded by the European Commission (EC).</p>
 ---
 
 {::nomarkdown}

--- a/pages/fundamentals/people/people-use-web/abilities-barriers/speech.md
+++ b/pages/fundamentals/people/people-use-web/abilities-barriers/speech.md
@@ -44,7 +44,7 @@ acknowledgements: /people-use-web/acknowledgements/ # Do not change this
 footer: >
   <p>Note about video description: The video on this page does not include synchronized audio description because the visuals only illustrate the audio and do not provide additional information. In this case, audio description would be more distracting than useful to most people, including people who cannot see the visuals. Description of visual information is available in the Text Transcript with Description of Visuals (“descriptive transcript”).</p>
   <p><strong>Editor:</strong> Shadi Abou-Zahra. Previous editor: Judy Brewer. Contributors listed in ACKNOWLEDGEMENTS.</p>
-  <p>Developed by the Education and Outreach Working Group (<a href="https//www.w3.org/WAI/EO/">EOWG</a>) with support from the <a href="https://www.w3.org/WAI/about/projects/wai-guide/">WAI-Guide Project</a> and <a href="https://www.w3.org/WAI/WAI-AGE/">WAI-AGE Project</a> co-funded by the European Commission (EC).</p>
+  <p>Developed by the Education and Outreach Working Group (<a href="https://www.w3.org/WAI/EO/">EOWG</a>) with support from the <a href="https://www.w3.org/WAI/about/projects/wai-guide/">WAI-Guide Project</a> and <a href="https://www.w3.org/WAI/WAI-AGE/">WAI-AGE Project</a> co-funded by the European Commission (EC).</p>
 ---
 
 {::nomarkdown}

--- a/pages/fundamentals/people/people-use-web/abilities-barriers/visual.md
+++ b/pages/fundamentals/people/people-use-web/abilities-barriers/visual.md
@@ -43,7 +43,7 @@ acknowledgements: /people-use-web/acknowledgements/ # Do not change this
 footer: >
   <p>Note about video description: The video on this page does not include synchronized audio description because the visuals only illustrate the audio and do not provide additional information. In this case, audio description would be more distracting than useful to most people, including people who cannot see the visuals. Description of visual information is available in the Text Transcript with Description of Visuals (“descriptive transcript”).</p>
   <p><strong>Editor:</strong> Shadi Abou-Zahra. Previous editor: Judy Brewer. Contributors listed in ACKNOWLEDGEMENTS.</p>
-  <p>Developed by the Education and Outreach Working Group (<a href="https//www.w3.org/WAI/EO/">EOWG</a>) with support from the <a href="https://www.w3.org/WAI/about/projects/wai-guide/">WAI-Guide Project</a> and <a href="https://www.w3.org/WAI/WAI-AGE/">WAI-AGE Project</a> co-funded by the European Commission (EC).</p>
+  <p>Developed by the Education and Outreach Working Group (<a href="https://www.w3.org/WAI/EO/">EOWG</a>) with support from the <a href="https://www.w3.org/WAI/about/projects/wai-guide/">WAI-Guide Project</a> and <a href="https://www.w3.org/WAI/WAI-AGE/">WAI-AGE Project</a> co-funded by the European Commission (EC).</p>
 ---
 
 {::nomarkdown}

--- a/pages/fundamentals/people/people-use-web/acknowledgements.md
+++ b/pages/fundamentals/people/people-use-web/acknowledgements.md
@@ -13,7 +13,7 @@ resource:
   ref: /people-use-web/
 ---
 
-<cite>How People with Disabilities Use the Web</cite> was developed by the Education and Outreach Working Group ([EOWG](https//www.w3.org/WAI/EO/)) with support from the [WAI-Guide Project](/about/projects/wai-guide/) and  [WAI-AGE Project](https://www.w3.org/WAI/WAI-AGE/) co-funded by the European Commission (EC).
+<cite>How People with Disabilities Use the Web</cite> was developed by the Education and Outreach Working Group ([EOWG](https://www.w3.org/WAI/EO/)) with support from the [WAI-Guide Project](/about/projects/wai-guide/) and  [WAI-AGE Project](https://www.w3.org/WAI/WAI-AGE/) co-funded by the European Commission (EC).
 
 ## 2021-2024 Updates
 
@@ -37,7 +37,7 @@ Additional contributors:
 - Mark Palmer
 - Shawn Lawton Henry
 - and participants of the
-[Education and Outreach Working Group (EOWG)](https//www.w3.org/WAI/EO/)
+[Education and Outreach Working Group (EOWG)](https://www.w3.org/WAI/EO/)
 
 EOWG leadership:
 - Co-Chairs during this revision: Brent Bakken (Pearson), Brian Elton (TPGi), Kris Anne Kinney (ETS), Sharron Rush (Knowbility)
@@ -51,7 +51,7 @@ Editors:
 
 Contributors: Brent Bakken, Eric Eggert, Robert Jolly, Laura Keen, Kris Anne Kinney,
 Howard Kramer, Shawn Lawton Henry, Sharron Rush, and participants of the
-[Education and Outreach Working Group (EOWG)](https//www.w3.org/WAI/EO/).
+[Education and Outreach Working Group (EOWG)](https://www.w3.org/WAI/EO/).
 
 ## Previous drafts
 

--- a/pages/fundamentals/people/people-use-web/tools-techniques/input.md
+++ b/pages/fundamentals/people/people-use-web/tools-techniques/input.md
@@ -43,7 +43,7 @@ acknowledgements: /people-use-web/acknowledgements/ # Do not change this
 footer: >
   <p>Note about video description: The video on this page does not include synchronized audio description because the visuals only illustrate the audio and do not provide additional information. In this case, audio description would be more distracting than useful to most people, including people who cannot see the visuals. Description of visual information is available in the Text Transcript with Description of Visuals (“descriptive transcript”).</p>
   <p><strong>Editor:</strong> Shadi Abou-Zahra. Previous editor: Judy Brewer. Contributors listed in ACKNOWLEDGEMENTS.</p>
-  <p>Developed by the Education and Outreach Working Group (<a href="https//www.w3.org/WAI/EO/">EOWG</a>) with support from the <a href="https://www.w3.org/WAI/about/projects/wai-guide/">WAI-Guide Project</a> and <a href="https://www.w3.org/WAI/WAI-AGE/">WAI-AGE Project</a> co-funded by the European Commission (EC).</p>
+  <p>Developed by the Education and Outreach Working Group (<a href="https://www.w3.org/WAI/EO/">EOWG</a>) with support from the <a href="https://www.w3.org/WAI/about/projects/wai-guide/">WAI-Guide Project</a> and <a href="https://www.w3.org/WAI/WAI-AGE/">WAI-AGE Project</a> co-funded by the European Commission (EC).</p>
 ---
 
 {::nomarkdown}

--- a/pages/fundamentals/people/people-use-web/tools-techniques/navigation.md
+++ b/pages/fundamentals/people/people-use-web/tools-techniques/navigation.md
@@ -42,7 +42,7 @@ acknowledgements: /people-use-web/acknowledgements/ # Do not change this
 footer: >
   <p>Note about video description: The video on this page does not include synchronized audio description because the visuals only illustrate the audio and do not provide additional information. In this case, audio description would be more distracting than useful to most people, including people who cannot see the visuals. Description of visual information is available in the Text Transcript with Description of Visuals (“descriptive transcript”).</p>
   <p><strong>Editor:</strong> Shadi Abou-Zahra. Previous editor: Judy Brewer. Contributors listed in ACKNOWLEDGEMENTS.</p>
-  <p>Developed by the Education and Outreach Working Group (<a href="https//www.w3.org/WAI/EO/">EOWG</a>) with support from the <a href="https://www.w3.org/WAI/about/projects/wai-guide/">WAI-Guide Project</a> and <a href="https://www.w3.org/WAI/WAI-AGE/">WAI-AGE Project</a> co-funded by the European Commission (EC).</p>
+  <p>Developed by the Education and Outreach Working Group (<a href="https://www.w3.org/WAI/EO/">EOWG</a>) with support from the <a href="https://www.w3.org/WAI/about/projects/wai-guide/">WAI-Guide Project</a> and <a href="https://www.w3.org/WAI/WAI-AGE/">WAI-AGE Project</a> co-funded by the European Commission (EC).</p>
 ---
 
 {::nomarkdown}

--- a/pages/fundamentals/people/people-use-web/tools-techniques/perception.md
+++ b/pages/fundamentals/people/people-use-web/tools-techniques/perception.md
@@ -43,7 +43,7 @@ acknowledgements: /people-use-web/acknowledgements/ # Do not change this
 footer: >
   <p>Note about video description: The video on this page does not include synchronized audio description because the visuals only illustrate the audio and do not provide additional information. In this case, audio description would be more distracting than useful to most people, including people who cannot see the visuals. Description of visual information is available in the Text Transcript with Description of Visuals (“descriptive transcript”).</p>
   <p><strong>Editor:</strong> Shadi Abou-Zahra. Previous editor: Judy Brewer. Contributors listed in ACKNOWLEDGEMENTS.</p>
-  <p>Developed by the Education and Outreach Working Group (<a href="https//www.w3.org/WAI/EO/">EOWG</a>) with support from the <a href="https://www.w3.org/WAI/about/projects/wai-guide/">WAI-Guide Project</a> and <a href="https://www.w3.org/WAI/WAI-AGE/">WAI-AGE Project</a> co-funded by the European Commission (EC).</p>
+  <p>Developed by the Education and Outreach Working Group (<a href="https://www.w3.org/WAI/EO/">EOWG</a>) with support from the <a href="https://www.w3.org/WAI/about/projects/wai-guide/">WAI-Guide Project</a> and <a href="https://www.w3.org/WAI/WAI-AGE/">WAI-AGE Project</a> co-funded by the European Commission (EC).</p>
 ---
 
 {::nomarkdown}

--- a/pages/fundamentals/people/people-use-web/tools-techniques/presentation.md
+++ b/pages/fundamentals/people/people-use-web/tools-techniques/presentation.md
@@ -43,7 +43,7 @@ acknowledgements: /people-use-web/acknowledgements/ # Do not change this
 footer: >
   <p>Note about video description: The video on this page does not include synchronized audio description because the visuals only illustrate the audio and do not provide additional information. In this case, audio description would be more distracting than useful to most people, including people who cannot see the visuals. Description of visual information is available in the Text Transcript with Description of Visuals (“descriptive transcript”).</p>
   <p><strong>Editor:</strong> Shadi Abou-Zahra. Previous editor: Judy Brewer. Contributors listed in ACKNOWLEDGEMENTS.</p>
-  <p>Developed by the Education and Outreach Working Group (<a href="https//www.w3.org/WAI/EO/">EOWG</a>) with support from the <a href="https://www.w3.org/WAI/about/projects/wai-guide/">WAI-Guide Project</a> and <a href="https://www.w3.org/WAI/WAI-AGE/">WAI-AGE Project</a> co-funded by the European Commission (EC).</p>
+  <p>Developed by the Education and Outreach Working Group (<a href="https://www.w3.org/WAI/EO/">EOWG</a>) with support from the <a href="https://www.w3.org/WAI/about/projects/wai-guide/">WAI-Guide Project</a> and <a href="https://www.w3.org/WAI/WAI-AGE/">WAI-AGE Project</a> co-funded by the European Commission (EC).</p>
 ---
 
 {::nomarkdown}

--- a/pages/fundamentals/people/people-use-web/user-stories/story-five.md
+++ b/pages/fundamentals/people/people-use-web/user-stories/story-five.md
@@ -42,7 +42,7 @@ footer: >
   <p>Note about video description: The video on this page does not include synchronized audio description because the visuals only illustrate the audio and do not provide additional information. In this case, audio description would be more distracting than useful to most people, including people who cannot see the visuals. Description of visual information is available in the Text Transcript with Description of Visuals (“descriptive transcript”).</p>
   <p>First posted as a draft in 1999.</p>
   <p><strong>Editors:</strong> Kevin White and Shadi Abou-Zahra. Previous editors: Judy Brewer and Norah Sinclair. Contributors: Brent Bakken, Jade Matos Carew, Jayne Schurick, Michele Williams, and others in ACKNOWLEDGEMENTS.</p>
-  <p>Developed by the Education and Outreach Working Group (<a href="https//www.w3.org/WAI/EO/">EOWG</a>) with support from the <a href="https://www.w3.org/WAI/about/projects/wai-guide/">WAI-Guide Project</a> and <a href="https://www.w3.org/WAI/WAI-AGE/">WAI-AGE Project</a> co-funded by the European Commission (EC).</p>
+  <p>Developed by the Education and Outreach Working Group (<a href="https://www.w3.org/WAI/EO/">EOWG</a>) with support from the <a href="https://www.w3.org/WAI/about/projects/wai-guide/">WAI-Guide Project</a> and <a href="https://www.w3.org/WAI/WAI-AGE/">WAI-AGE Project</a> co-funded by the European Commission (EC).</p>
 ---
 
 {::nomarkdown}

--- a/pages/fundamentals/people/people-use-web/user-stories/story-four.md
+++ b/pages/fundamentals/people/people-use-web/user-stories/story-four.md
@@ -42,7 +42,7 @@ footer: >
   <p>Note about video description: The video on this page does not include synchronized audio description because the visuals only illustrate the audio and do not provide additional information. In this case, audio description would be more distracting than useful to most people, including people who cannot see the visuals. Description of visual information is available in the Text Transcript with Description of Visuals (“descriptive transcript”).</p>
   <p>First posted as a draft in 1999.</p>
   <p><strong>Editors:</strong> Kevin White and Shadi Abou-Zahra. Previous editors: Judy Brewer and Norah Sinclair. Contributors: Brent Bakken, Jade Matos Carew, Jayne Schurick, Michele Williams, and others in ACKNOWLEDGEMENTS.</p>
-  <p>Developed by the Education and Outreach Working Group (<a href="https//www.w3.org/WAI/EO/">EOWG</a>) with support from the <a href="https://www.w3.org/WAI/about/projects/wai-guide/">WAI-Guide Project</a> and <a href="https://www.w3.org/WAI/WAI-AGE/">WAI-AGE Project</a> co-funded by the European Commission (EC).</p>
+  <p>Developed by the Education and Outreach Working Group (<a href="https://www.w3.org/WAI/EO/">EOWG</a>) with support from the <a href="https://www.w3.org/WAI/about/projects/wai-guide/">WAI-Guide Project</a> and <a href="https://www.w3.org/WAI/WAI-AGE/">WAI-AGE Project</a> co-funded by the European Commission (EC).</p>
 ---
 
 {::nomarkdown}

--- a/pages/fundamentals/people/people-use-web/user-stories/story-nine.md
+++ b/pages/fundamentals/people/people-use-web/user-stories/story-nine.md
@@ -41,7 +41,7 @@ footer: >
   <p>Note about video description: The video on this page does not include synchronized audio description because the visuals only illustrate the audio and do not provide additional information. In this case, audio description would be more distracting than useful to most people, including people who cannot see the visuals. Description of visual information is available in the Text Transcript with Description of Visuals (“descriptive transcript”).</p>
   <p>First posted as a draft in 1999.</p>
   <p><strong>Editors:</strong> Kevin White and Shadi Abou-Zahra. Previous editors: Judy Brewer and Norah Sinclair. Contributors: Brent Bakken, Jade Matos Carew, Jayne Schurick, Michele Williams, and others in ACKNOWLEDGEMENTS.</p>
-  <p>Developed by the Education and Outreach Working Group (<a href="https//www.w3.org/WAI/EO/">EOWG</a>) with support from the <a href="https://www.w3.org/WAI/about/projects/wai-guide/">WAI-Guide Project</a> and <a href="https://www.w3.org/WAI/WAI-AGE/">WAI-AGE Project</a> co-funded by the European Commission (EC).</p>
+  <p>Developed by the Education and Outreach Working Group (<a href="https://www.w3.org/WAI/EO/">EOWG</a>) with support from the <a href="https://www.w3.org/WAI/about/projects/wai-guide/">WAI-Guide Project</a> and <a href="https://www.w3.org/WAI/WAI-AGE/">WAI-AGE Project</a> co-funded by the European Commission (EC).</p>
 ---
 
 {::nomarkdown}

--- a/pages/fundamentals/people/people-use-web/user-stories/story-one.md
+++ b/pages/fundamentals/people/people-use-web/user-stories/story-one.md
@@ -42,7 +42,7 @@ footer: >
   <p>Note about video description: The video on this page does not include synchronized audio description because the visuals only illustrate the audio and do not provide additional information. In this case, audio description would be more distracting than useful to most people, including people who cannot see the visuals. Description of visual information is available in the Text Transcript with Description of Visuals (“descriptive transcript”).</p>
   <p>First posted as a draft in 1999.</p>
   <p><strong>Editors:</strong> Kevin White and Shadi Abou-Zahra. Previous editors: Judy Brewer and Norah Sinclair. Contributors: Brent Bakken, Jade Matos Carew, Jayne Schurick, Michele Williams, and others in ACKNOWLEDGEMENTS.</p>
-  <p>Developed by the Education and Outreach Working Group (<a href="https//www.w3.org/WAI/EO/">EOWG</a>) with support from the <a href="https://www.w3.org/WAI/about/projects/wai-guide/">WAI-Guide Project</a> and <a href="https://www.w3.org/WAI/WAI-AGE/">WAI-AGE Project</a> co-funded by the European Commission (EC).</p>
+  <p>Developed by the Education and Outreach Working Group (<a href="https://www.w3.org/WAI/EO/">EOWG</a>) with support from the <a href="https://www.w3.org/WAI/about/projects/wai-guide/">WAI-Guide Project</a> and <a href="https://www.w3.org/WAI/WAI-AGE/">WAI-AGE Project</a> co-funded by the European Commission (EC).</p>
 ---
 
 {::nomarkdown}

--- a/pages/fundamentals/people/people-use-web/user-stories/story-seven.md
+++ b/pages/fundamentals/people/people-use-web/user-stories/story-seven.md
@@ -42,7 +42,7 @@ footer: >
   <p>Note about video description: The video on this page does not include synchronized audio description because the visuals only illustrate the audio and do not provide additional information. In this case, audio description would be more distracting than useful to most people, including people who cannot see the visuals. Description of visual information is available in the Text Transcript with Description of Visuals (“descriptive transcript”).</p>
   <p>First posted as a draft in 1999.</p>
   <p><strong>Editors:</strong> Kevin White and Shadi Abou-Zahra. Previous editors: Judy Brewer and Norah Sinclair. Contributors: Brent Bakken, Jade Matos Carew, Jayne Schurick, Michele Williams, and others in ACKNOWLEDGEMENTS.</p>
-  <p>Developed by the Education and Outreach Working Group (<a href="https//www.w3.org/WAI/EO/">EOWG</a>) with support from the <a href="https://www.w3.org/WAI/about/projects/wai-guide/">WAI-Guide Project</a> and <a href="https://www.w3.org/WAI/WAI-AGE/">WAI-AGE Project</a> co-funded by the European Commission (EC).</p>
+  <p>Developed by the Education and Outreach Working Group (<a href="https://www.w3.org/WAI/EO/">EOWG</a>) with support from the <a href="https://www.w3.org/WAI/about/projects/wai-guide/">WAI-Guide Project</a> and <a href="https://www.w3.org/WAI/WAI-AGE/">WAI-AGE Project</a> co-funded by the European Commission (EC).</p>
 ---
 
 {::nomarkdown}

--- a/pages/fundamentals/people/people-use-web/user-stories/story-six.md
+++ b/pages/fundamentals/people/people-use-web/user-stories/story-six.md
@@ -42,7 +42,7 @@ footer: >
   <p>Note about video description: The video on this page does not include synchronized audio description because the visuals only illustrate the audio and do not provide additional information. In this case, audio description would be more distracting than useful to most people, including people who cannot see the visuals. Description of visual information is available in the Text Transcript with Description of Visuals (“descriptive transcript”).</p>
   <p>First posted as a draft in 1999.</p>
   <p><strong>Editors:</strong> Kevin White and Shadi Abou-Zahra. Previous editors: Judy Brewer and Norah Sinclair. Contributors: Brent Bakken, Jade Matos Carew, Jayne Schurick, Michele Williams, and others in ACKNOWLEDGEMENTS.</p>
-  <p>Developed by the Education and Outreach Working Group (<a href="https//www.w3.org/WAI/EO/">EOWG</a>) with support from the <a href="https://www.w3.org/WAI/about/projects/wai-guide/">WAI-Guide Project</a> and <a href="https://www.w3.org/WAI/WAI-AGE/">WAI-AGE Project</a> co-funded by the European Commission (EC).</p>
+  <p>Developed by the Education and Outreach Working Group (<a href="https://www.w3.org/WAI/EO/">EOWG</a>) with support from the <a href="https://www.w3.org/WAI/about/projects/wai-guide/">WAI-Guide Project</a> and <a href="https://www.w3.org/WAI/WAI-AGE/">WAI-AGE Project</a> co-funded by the European Commission (EC).</p>
 ---
 
 {::nomarkdown}

--- a/pages/fundamentals/people/people-use-web/user-stories/story-three.md
+++ b/pages/fundamentals/people/people-use-web/user-stories/story-three.md
@@ -42,7 +42,7 @@ footer: >
  <!--  <p>Note about video description: The video on this page does not include synchronized audio description because the visuals only illustrate the audio and do not provide additional information. In this case, audio description would be more distracting than useful to most people, including people who cannot see the visuals. Description of visual information is available in the Text Transcript with Description of Visuals (“descriptive transcript”).</p> -->
   <p>First posted as a draft in 1999.</p>
   <p><strong>Editors:</strong> Kevin White and Shadi Abou-Zahra. Previous editors: Judy Brewer and Norah Sinclair. Contributors: Brent Bakken, Jade Matos Carew, Jayne Schurick, Michele Williams, and others in ACKNOWLEDGEMENTS.</p>
-  <p>Developed by the Education and Outreach Working Group (<a href="https//www.w3.org/WAI/EO/">EOWG</a>) with support from the <a href="https://www.w3.org/WAI/about/projects/wai-guide/">WAI-Guide Project</a> and <a href="https://www.w3.org/WAI/WAI-AGE/">WAI-AGE Project</a> co-funded by the European Commission (EC).</p>
+  <p>Developed by the Education and Outreach Working Group (<a href="https://www.w3.org/WAI/EO/">EOWG</a>) with support from the <a href="https://www.w3.org/WAI/about/projects/wai-guide/">WAI-Guide Project</a> and <a href="https://www.w3.org/WAI/WAI-AGE/">WAI-AGE Project</a> co-funded by the European Commission (EC).</p>
 ---
 
 {::nomarkdown}

--- a/pages/fundamentals/people/people-use-web/user-stories/story-two.md
+++ b/pages/fundamentals/people/people-use-web/user-stories/story-two.md
@@ -42,7 +42,7 @@ footer: >
   <p>Note about video description: The video on this page does not include synchronized audio description because the visuals only illustrate the audio and do not provide additional information. In this case, audio description would be more distracting than useful to most people, including people who cannot see the visuals. Description of visual information is available in the Text Transcript with Description of Visuals (“descriptive transcript”).</p>
   <p>First posted as a draft in 1999.</p>
   <p><strong>Editors:</strong> Kevin White and Shadi Abou-Zahra. Previous editors: Judy Brewer and Norah Sinclair. Contributors: Brent Bakken, Jade Matos Carew, Jayne Schurick, Michele Williams, and others in ACKNOWLEDGEMENTS.</p>
-  <p>Developed by the Education and Outreach Working Group (<a href="https//www.w3.org/WAI/EO/">EOWG</a>) with support from the <a href="https://www.w3.org/WAI/about/projects/wai-guide/">WAI-Guide Project</a> and <a href="https://www.w3.org/WAI/WAI-AGE/">WAI-AGE Project</a> co-funded by the European Commission (EC).</p>
+  <p>Developed by the Education and Outreach Working Group (<a href="https://www.w3.org/WAI/EO/">EOWG</a>) with support from the <a href="https://www.w3.org/WAI/about/projects/wai-guide/">WAI-Guide Project</a> and <a href="https://www.w3.org/WAI/WAI-AGE/">WAI-AGE Project</a> co-funded by the European Commission (EC).</p>
 ---
 
 {::nomarkdown}


### PR DESCRIPTION
This is a follow-on from #1138, since I noticed there are several other instances of broken links due to missing `:` from `https://`.

Many of these are specifically in EOWG links; I suspect an earlier find/replace may have had a mistake in their replacement.

I have not changed any `last_updated` times in this PR, because it is only fixing a link typo, and either the link is updated across all translations as well, or there are no translations.