### PR TITLE
Move AGWG-specific Resolutions paragraph out of common include

### DIFF
--- a/_includes/minutes/resolutions.liquid
+++ b/_includes/minutes/resolutions.liquid
@@ -11,13 +11,6 @@ Inputs:
   <a href="./" aria-current="page">Resolutions</a>
 </p>
 
-<p>
-  Resolutions reflect general consensus of participants present in a meeting.
-  They are not formal decisions of the group. Refer to the
-  <a href="/WAI/GL/wiki/Decisions">Decisions</a> page for formal decisions.
-  Context for each resolution is available via its link into the minutes.
-</p>
-
 {%- if site.data.minutes[include.group] -%}
   {%- assign current_year = 0 -%}
   {% for minutes in site.data.minutes[include.group] %}

--- a/pages/about/groups/agwg/minutes/resolutions.md
+++ b/pages/about/groups/agwg/minutes/resolutions.md
@@ -10,6 +10,13 @@ github:
 
 This page shows minutes of the Accessibility Guidelines Working Group. Minutes for task forces are available from their respective pages.
 
+<p>
+  Resolutions reflect general consensus of participants present in a meeting.
+  They are not formal decisions of the group. Refer to the
+  <a href="/WAI/GL/wiki/Decisions">Decisions</a> page for formal decisions.
+  Context for each resolution is available via its link into the minutes.
+</p>
+
 {::nomarkdown}
 {% include minutes/resolutions.liquid group="gl" %}
 {:/}


### PR DESCRIPTION
When reviewing #1119, @remibetin flagged that the blurb that appeared near the top of Resolutions pages was seemingly applied too broadly, as it referenced an AGWG-specific Decisions page but showed up even on APA- and ARIA-related minutes pages.

I followed up with @iadawn today as to whether this should appear on only specifically the AGWG minutes page or AGWG + all TFs under it, and he answered the former.

This PR moves the paragraph out of the common Resolutions include, into specifically the AGWG Resolutions page.

Note that the path of least resistance involves moving the paragraph up above the Minutes / Topics / Resolutions links; if we really want to maintain the order, I may need to juggle some includes.

[Preview](https://deploy-preview-1152--wai-website.netlify.app/about/groups/agwg/minutes/resolutions/)

I will reach out to Daniel and Roy as to whether there are equivalent pages that would make sense to link from ARIA and APA minutes, respectively.