### PR TITLE
Contacting WAI: fix link to W3C media kit

### DIFF
--- a/pages/about/contacting.md
+++ b/pages/about/contacting.md
@@ -30,7 +30,7 @@ class: tight-page
 
 For press inquiries on accessibility or the Web Accessibility Initiative (WAI), please email [w3t-pr@w3.org and shawn@w3.org](mailto:shawn@w3.org,w3t-pr@w3.org?subject=press%20request-accessibility).
 
-Additional information is in the [W3C media kit](/about/press-media/).
+Additional information is in the [W3C media kit](https://www.w3.org/about/press-media/).
 
 ## Technical, implementation, and other support questions
 


### PR DESCRIPTION
Fixes https://github.com/w3c/wai-website/pull/1227

<!--Describe the pull request below.-->

In Jekyll, a Markdown link that uses a relative path starting with `/` is interpreted as "relative to the site root directory", i.e. /WAI.

As a result, `/about/press-media/` was converted into https://www.w3.org/WAI/about/press-media/ instead of https://www.w3.org/about/press-media/.

In this type of case, an absolute URL is needed.

<!--If your PR has a primary page for review, set an entry path.
    Add a relative path next to `@netlify` below.-->

@netlify /about/contacting/