### PR TITLE
Dependabot: allow up to 10 open PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,5 +12,7 @@ updates:
       # Check for submodules updates at 6:45am UTC. Not choosing the start of an hour to decrease the chance of delay.
       # https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#schedule
       time: "06:45"
+    # Allow Dependabot to open up to 10 PR
+    open-pull-requests-limit: 10
     labels:
       - "submodules"


### PR DESCRIPTION
Dependabot is used to manage submodules version updates. However, by default, Dependabot stop raising pull requests if five PR with version updates are open.

This PR uses the [`open-pull-requests-limit` option](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#open-pull-requests-limit-) to increase this limit up to 10 PRs, considering that the WAI website contains 10 submodules.
