### PR TITLE
Add link to meeting minutes topic scraper on all minutes pages

### DIFF
--- a/_includes/minutes/fallback.liquid
+++ b/_includes/minutes/fallback.liquid
@@ -10,7 +10,7 @@ Expected input:
 <p>Minutes listings are temporarily unavailable. Sorry for the inconvenience.</p>
 <p>
   For details of the current work, see an alternative view of
-  <a href="https://www.w3.org/services/meeting-minutes?num=200&channels={{ site.data.minutes.groups[include.group] | join: ',' }}">meeting minutes</a>.
+  {% include_cached minutes/services-link.liquid group=include.group %}.
 </p>
 
 {% include box.html type="end" %}

--- a/_includes/minutes/minutes.liquid
+++ b/_includes/minutes/minutes.liquid
@@ -12,6 +12,11 @@ Inputs:
 </p>
 
 {%- if site.data.minutes[include.group] -%}
+  <p>
+    For details of the most recent work, see an alternative view of
+    {% include_cached minutes/services-link.liquid group=include.group %}.
+  </p>
+
   {%- assign current_year = 0 -%}
   {% for minutes in site.data.minutes[include.group] %}
     {%- capture date %}{{ minutes[0] | truncate: 10, "" }}{% endcapture -%}

--- a/_includes/minutes/minutes.liquid
+++ b/_includes/minutes/minutes.liquid
@@ -12,10 +12,7 @@ Inputs:
 </p>
 
 {%- if site.data.minutes[include.group] -%}
-  <p>
-    For details of the most recent work, see an alternative view of
-    {% include_cached minutes/services-link.liquid group=include.group %}.
-  </p>
+  {% include_cached minutes/more-recent.liquid group=include.group %}
 
   {%- assign current_year = 0 -%}
   {% for minutes in site.data.minutes[include.group] %}

--- a/_includes/minutes/more-recent.liquid
+++ b/_includes/minutes/more-recent.liquid
@@ -1,0 +1,13 @@
+{%- comment %}
+Renders paragraph indicating time of last update, and
+linking to meeting minutes topic scraper for more recent minutes.
+
+Expected input:
+- group - name of group, matching a key in _data/minutes/groups.json
+{% endcomment -%}
+
+<p>
+  This page was last updated on {{ site.time | date: "%e %B %Y at %I:%M %p %Z" }}.
+  For more recent meetings, see an alternative view of
+  {% include_cached minutes/services-link.liquid group=include.group %}.
+</p>

--- a/_includes/minutes/more-recent.liquid
+++ b/_includes/minutes/more-recent.liquid
@@ -7,7 +7,7 @@ Expected input:
 {% endcomment -%}
 
 <p>
-  This page was last updated on {{ site.time | date: "%e %B %Y at %I:%M %p %Z" }}.
+  This page was last updated on {{ site.time | date: "%e %B %Y" }}.
   For more recent meetings, see an alternative view of
   {% include_cached minutes/services-link.liquid group=include.group %}.
 </p>

--- a/_includes/minutes/resolutions.liquid
+++ b/_includes/minutes/resolutions.liquid
@@ -12,6 +12,11 @@ Inputs:
 </p>
 
 {%- if site.data.minutes[include.group] -%}
+  <p>
+    For details of the most recent work, see an alternative view of
+    {% include_cached minutes/services-link.liquid group=include.group %}.
+  </p>
+
   {%- assign current_year = 0 -%}
   {% for minutes in site.data.minutes[include.group] %}
     {%- unless minutes[1].resolutions.size %}{% continue %}{% endunless -%}

--- a/_includes/minutes/resolutions.liquid
+++ b/_includes/minutes/resolutions.liquid
@@ -12,10 +12,7 @@ Inputs:
 </p>
 
 {%- if site.data.minutes[include.group] -%}
-  <p>
-    For details of the most recent work, see an alternative view of
-    {% include_cached minutes/services-link.liquid group=include.group %}.
-  </p>
+  {% include_cached minutes/more-recent.liquid group=include.group %}
 
   {%- assign current_year = 0 -%}
   {% for minutes in site.data.minutes[include.group] %}

--- a/_includes/minutes/services-link.liquid
+++ b/_includes/minutes/services-link.liquid
@@ -1,0 +1,7 @@
+{%- comment %}
+Renders link to meeting minutes topic scraper.
+
+Expected input:
+- group - name of group, matching a key in _data/minutes/groups.json
+{% endcomment -%}
+<a href="https://www.w3.org/services/meeting-minutes?num=200&channels={{ site.data.minutes.groups[include.group] | join: ',' }}">meeting minutes</a>

--- a/_includes/minutes/topics.liquid
+++ b/_includes/minutes/topics.liquid
@@ -12,6 +12,11 @@ Inputs:
 </p>
 
 {%- if site.data.minutes[include.group] -%}
+  <p>
+    For details of the most recent work, see an alternative view of
+    {% include_cached minutes/services-link.liquid group=include.group %}.
+  </p>
+
   {%- assign current_year = 0 -%}
   {% for minutes in site.data.minutes[include.group] %}
     {%- capture date %}{{ minutes[0] | truncate: 10, "" }}{% endcapture -%}

--- a/_includes/minutes/topics.liquid
+++ b/_includes/minutes/topics.liquid
@@ -12,10 +12,7 @@ Inputs:
 </p>
 
 {%- if site.data.minutes[include.group] -%}
-  <p>
-    For details of the most recent work, see an alternative view of
-    {% include_cached minutes/services-link.liquid group=include.group %}.
-  </p>
+  {% include_cached minutes/more-recent.liquid group=include.group %}
 
   {%- assign current_year = 0 -%}
   {% for minutes in site.data.minutes[include.group] %}


### PR DESCRIPTION
Fixes #1279.

This adds a link to the meeting minutes scraper, as an alternative for when there hasn't yet been a redeploy since the most recent minutes for a WG/TF.

This adds a paragraph under the minutes/topics/resolutions links:

![Screenshot showing paragraph after existing links: "This page was last updated on 22 May 2025 at 11:29 AM EDT. For more recent meetings, see an alternative view of meeting minutes." The words "meeting minutes" link to the topic scraper page.](https://github.com/user-attachments/assets/76dbfb83-4c53-4107-81dd-eff0d8ada8ca)


The fallback box behavior (in the event of the plugin failing to retrieve data) remains the same, and the new paragraph does not show in that case, as it would be redundant:

![Screenshot showing the existing fallback box, which includes the paragraph: "For details of the current work, see an alternative view of meeting minutes." The words "meeting minutes" again link to the topic scraper page.](https://github.com/user-attachments/assets/34984712-e4d6-48ec-bff5-1716be559259)


@netlify /about/groups/agwg/minutes/