### PR TITLE
WG includes TFs

### DIFF
--- a/pages/about/groups/index.md
+++ b/pages/about/groups/index.md
@@ -16,7 +16,7 @@ The Web Accessibility Initiative (WAI)’s working groups develop digital access
 
 The mission of the [Accessibility Guidelines (AG) Working Group](/about/groups/agwg/) is to develop and maintain specifications for making web content accessible to people with disabilities, along with support materials for implementing the Web Content Accessibility Guidelines (WCAG).
 
-The AG Working Group is supported by the:
+The AG Working Group includes the:
 
  - [Accessibility Conformance Testing Task Force](/about/groups/task-forces/conformance-testing/)
  - [Cognitive and Learning Disabilities Accessibility Task Force](/about/groups/task-forces/coga/)
@@ -29,7 +29,7 @@ The AG Working Group is supported by the:
 
 The mission of the [Accessible Platform Architectures (APA) Working Group](/about/groups/apawg/) is to ensure W3C specifications support accessibility for people with disabilities through the following activities: reviewing specifications; developing new specifications and technical support materials; collaborating with other W3C working groups on technology accessibility; and coordinating harmonized accessibility strategies within W3C that include security, privacy, and internationalization.
 
-The APA Working Group is supported by the:
+The APA Working Group includes the:
 
  - [Framework for Accessible Specification of Technologies Task Force](/about/groups/task-forces/fast/)
  - [Maturity Model Task Force](/about/groups/task-forces/maturity-model/)
@@ -41,7 +41,7 @@ The APA Working Group is supported by the:
 
 The mission of the [Accessible Rich Internet Applications (ARIA) Working Group](/about/groups/ariawg/) is to enhance the accessibility of web content through developing supplemental attributes that can be applied to native host language interactive elements and exposed via platform accessibility application programming interfaces (APIs).
 
-The ARIA Working Group is supported by the:
+The ARIA Working Group includes the:
 
  - [Authoring Practices Guide Task Force](/about/groups/task-forces/practices/)
  - [Portable Document Format Accessibility APIs Mapping Task Force](/about/groups/task-forces/pdf-aam/)


### PR DESCRIPTION
"Working Group is supported by the" to me sounds like the TFs are separate from the WG.

It's important to clearly communicate that the TFs are part of the WG. case in point : https://lists.w3.org/Archives/Team/w3t-comm/2025Jun/0045.html

<!--Describe the pull request below.-->


<!--If your PR has a primary page for review, set an entry path.
    Add a relative path next to `@netlify` below.-->

@netlify /