### PR TITLE
Remove parenthetical from heading in wcag2x-backlog TF page

### DIFF
--- a/pages/about/groups/task-forces/wcag2x-backlog.md
+++ b/pages/about/groups/task-forces/wcag2x-backlog.md
@@ -91,6 +91,6 @@ Once you are a member of the AG Working Group, email the [W3C staff contact for 
 
 The WCAG 2.x Backlog Task Force does not develop publications.
 
-## Contact the facilitators (not chairs? why the inconsistency?)
+## Contact the facilitators
 
 If you have a question for the WCAG 2.x Backlog Task Force, email the [chairs](https://www.w3.org/groups/tf/wcag2x-backlog/participants/#chairs) or the [W3C staff contact](https://www.w3.org/groups/tf/wcag2x-backlog/participants/#staff).


### PR DESCRIPTION
This apparently slipped through in #1018. I am opting to remove the parenthetical, since the Backlog TF does regularly use the term Facilitator.

@netlify /about/groups/task-forces/wcag2x-backlog/