### PR TITLE
Participating and Sitemap pages: update Support page link text

### DIFF
--- a/pages/about/participating.md
+++ b/pages/about/participating.md
@@ -107,13 +107,13 @@ and to get information on participation.
 -   **[APA](/WAI/APA/)** &mdash; The Accessible Platform Architectures (APA) Working Group reviews W3C's specifications for accessibility support and develops technical support materials. **See [Participating in APA WG](/WAI/APA/participation)**.
 -   **[ARIA](/WAI/ARIA/)** &mdash; The Accessible Rich Internet Applications Working Group develops a suite of accessible rich internet applications (ARIA) resources, and accessible APIs and mappings. **See [Participating in ARIA WG](/WAI/ARIA/participation)**.
 
-## Sponsoring WAI
+## Support WAI Financially
 
 WAI's work is supported in part by sponsorship from industry,
 disability, and government organizations interested in contributing to
 WAI's efforts to make the web more accessible. Please see the list of
-current sponsors and information on WAI sponsorship at [Sponsoring
-WAI]({{"/about/support/" | relative_url }}).
+current sponsors and information on WAI sponsorship at [[Support
+WAI Financially]](/about/support/).
 
 ## Promoting and Implementing Web Accessibility
 

--- a/pages/sitemap.md
+++ b/pages/sitemap.md
@@ -65,7 +65,7 @@ _To get short descriptions of primary content, see [[WAI Resources]](/resources/
   - [WAI Interest Group (WAI IG)]({{ "/about/groups/waiig/" | relative_url }})
   - [Group Task Forces]({{ "/about/groups/taskforces/" | relative_url }})
 - [[Translating WAI Documents]](/about/translating/)
-- [[Sponsoring WAI]](/about/support/)
+- [[Support WAI Financially]](/about/support/)
 - [[Contacting WAI]](/about/contacting/)
 - [[WAI Projects]](/about/projects/) &mdash; lists current and past projects
 - [[Accessibility Statement for WAI Website]](/about/accessibility-statement/)


### PR DESCRIPTION
@shawna-slh This PR uses the new "Support WAI Financially" title in the Participating and Sitemap pages.

<!--If your PR has a primary page for review, set an entry path.
    Add a relative path next to `@netlify` below.-->

@netlify /about/participating/