### PR TITLE
W3C Process for Developing Standards: fix link to the Process Document

### DIFF
--- a/pages/standards-guidelines/w3c-process.fr.md
+++ b/pages/standards-guidelines/w3c-process.fr.md
@@ -6,10 +6,10 @@ title: "Comment WAI élabore les standards d'accessibilité selon le processus d
 title_html: "Comment WAI élabore les standards d'accessibilité selon le processus du W3C :<br> étapes importantes et opportunités pour contribuer"
 nav_title: Processus du W3C pour élaborer les standards
 lang: fr
-last_updated: 2024-01-15   # Keep the date of the English version
+last_updated: 2025-07-09   # Keep the date of the English version
 
 translation:
-  last_updated: 2024-05-07   # Put the date of this translation YYYY-MM-DD (with month in the middle)
+  last_updated: 2025-07-09   # Put the date of this translation YYYY-MM-DD (with month in the middle)
 
 translators:
   - name: "Sofia Ahmed"
@@ -89,7 +89,7 @@ Les étapes importantes par lesquelles passe un « rapport technique » du W3C
 4. {:#pr}![Approuver le rapport technique :]({{ "/content-images/w3c-process/pr.gif" | relative_url }}){:style="float:left; margin-right: 1em; clear: left;"} **Proposition de recommandation (<i lang="en">Proposed Recommendation</i> en anglais)** : après des implémentations de  chaque fonctionnalité du rapport technique, W3C annonce qu'il s'agit désormais d'une « Proposition de recommandation ». À ce stade, le rapport est soumis aux membres du W3C pour être approuvé.
 5. {:#rec}![approved technical report:]({{ "/content-images/w3c-process/rec.gif" | relative_url }}){:style="float:left; margin-right: 1em; clear: left;"} **Recommandation du W3C (Standard du Web)** : Une fois que le rapport technique a reçu un soutien significatif de la part des membres du W3C, du directeur du W3C et du public, il est publié en tant que « Recommandation ». W3C encourage le déploiement à grande échelle de ses « Recommandations ».
 
-Il s'agit d'une description simplifiée du processus. Pour la version faisant autorité, consultez le [document sur le processus du W3C, section 7 : Processus de développement d'un rapport technique du W3C](https://www.w3.org/Consortium/Process/#Reports).
+Il s'agit d'une description simplifiée du processus. Pour la version faisant autorité, consultez le [document sur le processus du W3C : Rapports techniques du W3C](https://www.w3.org/Consortium/Process/#Reports).
 
 ## Autres ressources {#other}
 

--- a/pages/standards-guidelines/w3c-process.md
+++ b/pages/standards-guidelines/w3c-process.md
@@ -6,7 +6,7 @@ title: "How WAI Develops Accessibility Standards through the W3C Process: Milest
 title_html: "How WAI Develops Accessibility Standards through the W3C Process:<br> Milestones and Opportunities to Contribute"
 nav_title: W3C Process for Developing Standards
 lang: en   # Change "en" to the translated-language shortcode
-last_updated: 2024-01-15   # Keep the date of the English version
+last_updated: 2025-07-09   # Keep the date of the English version
 first_published: "September 2006"
 
 # translators: # remove from the beginning of this line and the lines below: "# " (the hash sign and the space)
@@ -85,7 +85,7 @@ The milestones that a W3C "technical report" goes through on its way to becoming
 4. {:#pr}![endorsing technical report:]({{ "/content-images/w3c-process/pr.gif" | relative_url }}){:style="float:left; margin-right: 1em; clear: left;"} **Proposed Recommendation**: After there are implementations of each feature of the technical report, W3C announces it as a Proposed Recommendation. At this stage, the report is submitted to the W3C Membership for endorsement.
 5. {:#rec}![approved technical report:]({{ "/content-images/w3c-process/rec.gif" | relative_url }}){:style="float:left; margin-right: 1em; clear: left;"} **W3C Recommendation (Web Standard)**: Once there is significant support for the technical report from the W3C Members, the W3C Director, and the public, it is published as a Recommendation. W3C encourages widespread deployment of its Recommendations.
 
-That was a simplified description of the process. For the definitive version, see the [W3C Process Document, Section 7: W3C Technical Report Development Process](https://www.w3.org/Consortium/Process/#Reports).
+That was a simplified description of the process. For the definitive version, see the [W3C Process Document: W3C Technical Reports](https://www.w3.org/policies/process/#Reports).
 
 ## Other Resources {#other}
 

--- a/pages/standards-guidelines/w3c-process/changelog.md
+++ b/pages/standards-guidelines/w3c-process/changelog.md
@@ -1,0 +1,18 @@
+---
+# Do not translate this
+title: "Changelog for How WAI Develops Accessibility Standards through the W3C Process"
+title_html: "Changelog for <a href='/WAI/standards-guidelines/w3c-process/'>How WAI Develops Accessibility Standards through the W3C Process</a>"
+nav_title: "Changelog"
+lang: en
+
+github:
+  label: wai-w3c-process
+
+permalink: /standards-guidelines/w3c-process/changelog/
+ref: /standards-guidelines/w3c-process/changelog/
+---
+
+
+## 9 July 2025
+
+- In the [“Milestones” section](/standards-guidelines/w3c-process/#milestones): updated the link to the W3C Process Document.


### PR DESCRIPTION
Context: https://github.com/w3c/wai-website/issues/450

<!--Describe the pull request below.-->
This PR:
- updates the link to the complete description of the W3C Process for Technical reports
- does not mention the section number in the W3C Process Document, to shorten the link text
- adds a changelog page

<!--If your PR has a primary page for review, set an entry path.
    Add a relative path next to `@netlify` below.-->

@netlify /standards-guidelines/w3c-process/