### PR TITLE
Groups and task forces: apply most changes from #1107

### DIFF
--- a/pages/about/groups/agwg.md
+++ b/pages/about/groups/agwg.md
@@ -39,10 +39,7 @@ Find out about the activities of the Accessibility Guidelines (AG) Working Group
 
 The mission of the AG Working Group is to develop and maintain specifications for making web content accessible to people with disabilities, along with support materials for implementing the Web Content Accessibility Guidelines (WCAG).
 
-## Charter
-
-To learn about the group’s focus, scope and deliverables, see the [AG Working Group Charter](https://www.w3.org/WAI/GL/charter).
-
+To learn about the group’s focus, scope and deliverables, see the [AG Working Group Charter](https://www.w3.org/2023/11/ag-charter).
 
 ## Current work 
 
@@ -51,6 +48,8 @@ For details of the current work, see the [AG Working Group wiki](https://www.w3.
 ### WCAG 3
 
 Work on developing WCAG 3 takes place in many task forces and subgroups of the AG Working Group. For information about the WCAG 3 timelines and publication plan, see [WCAG 3 Timeline](https://www.w3.org/WAI/GL/wiki/WCAG_3_Timeline).
+
+WCAG 3 is still years away from becoming a W3C standard. For more information, see [WCAG 3 Introduction](https://www.w3.org/WAI/standards-guidelines/wcag/wcag3-intro/).
 
 ### WCAG 2.2
 
@@ -61,15 +60,17 @@ The [WCAG 2.x Backlog Task Force](/about/groups/task-forces/wcag2x-backlog/) mai
 
 For current outstanding WCAG 2.x issues, see [WCAG issues &mdash; GitHub](https://github.com/w3c/wcag/issues/).
 
+WCAG 2.2 is the current W3C standard and will remain so until WCAG 3 replaces it. For more information, see [WCAG 2 Overview](https://www.w3.org/WAI/standards-guidelines/wcag/).
+
 ## Contribute to the work
 
-W3C and the AG Working Group welcome input on WCAG work from the global accessibility community.
+W3C and the AG Working Group welcome input on WCAG work from individuals and organizations around the world.
 
 ### Contribute without joining the group
 
 There are ways you can contribute without being a member of the working group:
 
-* **Comment on publications:** During development, the group publishes working drafts for public comment &mdash; these are announced on the [WAI News pages](/news/) and on the [WAI Interest Group mailing lists](/about/groups/waiig/#mailinglist).
+* **Comment on publications:** During development, the group publishes working drafts for public comment &mdash; to be notified about draft documents for review, [subscribe to WAI news](https://www.w3.org/WAI/news/subscribe/).
 * **Raise, comment on, or propose fixes to WCAG issues:** If you’re aware of an issue with any of the published WCAG 2.x resources, W3C welcomes you to [raise a new issue on GitHub](https://github.com/w3c/wcag/issues/) &mdash; you can also comment on and, even better, propose solutions for existing issues.
 * **Contribute to WCAG 3 discussions:** As WCAG 3 develops, many topics are being discussed &mdash; to contribute your views, see the list of [open WCAG 3 discussions in GitHub](https://github.com/w3c/wcag3/discussions) and [mailing list discussions](https://lists.w3.org/Archives/Public/w3c-wai-gl/).
 * **Participate in a community group:** W3C hosts a small number of active community groups that focus on digital accessibility issues &mdash; for details, search for ‘accessibility’ on [Current Groups &mdash; W3C Community and Business Groups](https://www.w3.org/community/groups/).
@@ -86,7 +87,7 @@ Being a participant involves commitment to support the work of the group in the 
 
 See [Instructions for joining the Accessibility Guidelines Working Group](https://www.w3.org/groups/wg/ag/instructions/).
 
-## Group members and task forces
+## Group participants and task forces
 
 * [Chairs](https://www.w3.org/groups/wg/ag/participants/#chairs)
 * [Current participants](https://www.w3.org/groups/wg/ag/participants/#participants)
@@ -112,7 +113,7 @@ The AG Working Group maintains the following GitHub repositories:
 
 ## Publications and copyright
 
-[List of technical reports published by the AG Working Group](https://www.w3.org/groups/wg/ag/publications/).
+[List of technical reports published by the AG Working Group](https://www.w3.org/groups/wg/ag/publications/)
 
 W3C maintains a public list of any patent disclosures made in connection with the deliverables of the group &mdash; for details, see [Intellectual property rights &mdash; AG Working Group](https://www.w3.org/groups/wg/ag/ipr/).
 

--- a/pages/about/groups/agwg.md
+++ b/pages/about/groups/agwg.md
@@ -49,7 +49,7 @@ For details of the current work, see the [AG Working Group wiki](https://www.w3.
 
 Work on developing WCAG 3 takes place in many task forces and subgroups of the AG Working Group. For information about the WCAG 3 timelines and publication plan, see [WCAG 3 Timeline](https://www.w3.org/WAI/GL/wiki/WCAG_3_Timeline).
 
-WCAG 3 is still years away from becoming a W3C standard. For more information, see [WCAG 3 Introduction](https://www.w3.org/WAI/standards-guidelines/wcag/wcag3-intro/).
+WCAG 3 is still years away from becoming a W3C standard. For more information, see [WCAG 3 Introduction](/standards-guidelines/wcag/wcag3-intro/).
 
 ### WCAG 2.2
 
@@ -60,7 +60,7 @@ The [WCAG 2.x Backlog Task Force](/about/groups/task-forces/wcag2x-backlog/) mai
 
 For current outstanding WCAG 2.x issues, see [WCAG issues &mdash; GitHub](https://github.com/w3c/wcag/issues/).
 
-WCAG 2.2 is the current W3C standard and will remain so until WCAG 3 replaces it. For more information, see [WCAG 2 Overview](https://www.w3.org/WAI/standards-guidelines/wcag/).
+WCAG 2.2 is the current W3C standard and will remain so until WCAG 3 replaces it. For more information, see [WCAG 2 Overview](/standards-guidelines/wcag/).
 
 ## Contribute to the work
 
@@ -70,7 +70,7 @@ W3C and the AG Working Group welcome input on WCAG work from individuals and org
 
 There are ways you can contribute without being a member of the working group:
 
-* **Comment on publications:** During development, the group publishes working drafts for public comment &mdash; to be notified about draft documents for review, [subscribe to WAI news](https://www.w3.org/WAI/news/subscribe/).
+* **Comment on publications:** During development, the group publishes working drafts for public comment &mdash; to be notified about draft documents for review, [subscribe to WAI news](/news/subscribe/).
 * **Raise, comment on, or propose fixes to WCAG issues:** If you’re aware of an issue with any of the published WCAG 2.x resources, W3C welcomes you to [raise a new issue on GitHub](https://github.com/w3c/wcag/issues/) &mdash; you can also comment on and, even better, propose solutions for existing issues.
 * **Contribute to WCAG 3 discussions:** As WCAG 3 develops, many topics are being discussed &mdash; to contribute your views, see the list of [open WCAG 3 discussions in GitHub](https://github.com/w3c/wcag3/discussions) and [mailing list discussions](https://lists.w3.org/Archives/Public/w3c-wai-gl/).
 * **Participate in a community group:** W3C hosts a small number of active community groups that focus on digital accessibility issues &mdash; for details, search for ‘accessibility’ on [Current Groups &mdash; W3C Community and Business Groups](https://www.w3.org/community/groups/).

--- a/pages/about/groups/apawg.md
+++ b/pages/about/groups/apawg.md
@@ -61,7 +61,7 @@ W3C and the APA Working Group welcome input on APA work from individuals and org
 
 There are ways you can contribute without being a member of the working group:
 
-* **Comment on publications:** During development, the group publishes working drafts for public comment &mdash; to be notified about draft documents for review, [subscribe to WAI news](https:///news/subscribe/).
+* **Comment on publications:** During development, the group publishes working drafts for public comment &mdash; to be notified about draft documents for review, [subscribe to WAI news](/news/subscribe/).
 * **Raise, comment on, or propose fixes to APA issues:** If you’re aware of an issue with any of the published APA resources, W3C welcomes you to [raise a new issue on GitHub](https://github.com/w3c/apa/issues) &mdash; you can also comment on and, even better, propose solutions for existing issues.
 * **Contribute to APA discussions:** You may contribute your views to the APA Working Group's [mailing list discussions](https://lists.w3.org/Archives/Public/public-apa/).
 

--- a/pages/about/groups/apawg.md
+++ b/pages/about/groups/apawg.md
@@ -61,7 +61,7 @@ W3C and the APA Working Group welcome input on APA work from individuals and org
 
 There are ways you can contribute without being a member of the working group:
 
-* **Comment on publications:** During development, the group publishes working drafts for public comment &mdash; to be notified about draft documents for review, [subscribe to WAI news](https://www.w3.org/WAI/news/subscribe/).
+* **Comment on publications:** During development, the group publishes working drafts for public comment &mdash; to be notified about draft documents for review, [subscribe to WAI news](https:///news/subscribe/).
 * **Raise, comment on, or propose fixes to APA issues:** If you’re aware of an issue with any of the published APA resources, W3C welcomes you to [raise a new issue on GitHub](https://github.com/w3c/apa/issues) &mdash; you can also comment on and, even better, propose solutions for existing issues.
 * **Contribute to APA discussions:** You may contribute your views to the APA Working Group's [mailing list discussions](https://lists.w3.org/Archives/Public/public-apa/).
 

--- a/pages/about/groups/apawg.md
+++ b/pages/about/groups/apawg.md
@@ -40,9 +40,12 @@ Find out about the activities of the Accessible Platform Architectures (APA) Wor
 
 ## Mission
 
-The mission of the APA Working Group is to ensure W3C specifications support accessibility for people with disabilities through the following activities: reviewing specifications; developing new specifications and technical support materials; collaborating with other W3C working groups on technology accessibility; and coordinating harmonized accessibility strategies within W3C that include security, privacy, and internationalization.
+The mission of the APA Working Group is to ensure W3C specifications support accessibility for people with disabilities through the following activities: 
 
-## Charter
+* reviewing specifications
+* developing new specifications and technical support materials
+* collaborating with other W3C working groups on technology accessibility
+* coordinating harmonized accessibility strategies within W3C that include security, privacy, and internationalization
 
 To learn about the group’s focus, scope and deliverables, see the [APA Working Group Charter](https://www.w3.org/2023/07/apa-wg-charter).
 
@@ -52,13 +55,13 @@ For details of the current work, see the [APA Working Group wiki](https://www.w3
 
 ## Contribute to the work
 
-W3C and the APA Working Group welcome input on APA work from the global accessibility community.
+W3C and the APA Working Group welcome input on APA work from individuals and organizations around the world.
 
 ### Contribute without joining the group
 
 There are ways you can contribute without being a member of the working group:
 
-* **Comment on publications:** During development, the group publishes working drafts for public comment &mdash; these are announced on the [WAI News pages](/news/) and on the [WAI Interest Group mailing lists](/about/groups/waiig/#mailinglist).
+* **Comment on publications:** During development, the group publishes working drafts for public comment &mdash; to be notified about draft documents for review, [subscribe to WAI news](https://www.w3.org/WAI/news/subscribe/).
 * **Raise, comment on, or propose fixes to APA issues:** If you’re aware of an issue with any of the published APA resources, W3C welcomes you to [raise a new issue on GitHub](https://github.com/w3c/apa/issues) &mdash; you can also comment on and, even better, propose solutions for existing issues.
 * **Contribute to APA discussions:** You may contribute your views to the APA Working Group's [mailing list discussions](https://lists.w3.org/Archives/Public/public-apa/).
 
@@ -74,7 +77,7 @@ Being a participant involves commitment to support the work of the group in the 
 
 See [Instructions for joining the Accessible Platform Architectures Working Group](https://www.w3.org/groups/wg/apa/instructions/).
 
-## Group members and task forces
+## Group participants and task forces
 
 * [Chairs](https://www.w3.org/groups/wg/apa/participants/#chairs)
 * [Current participants](https://www.w3.org/groups/wg/apa/participants/#participants)

--- a/pages/about/groups/ariawg.md
+++ b/pages/about/groups/ariawg.md
@@ -45,8 +45,6 @@ Find out about the activities of the Accessible Rich Internet Applications (ARIA
 
 The mission of the ARIA Working Group is to enhance the accessibility of web content through developing supplemental attributes that can be applied to native host language interactive elements and exposed via platform accessibility application programming interfaces (APIs).
 
-## Charter
-
 To learn about the group’s focus, scope and deliverables, see the [ARIA Working Group Charter](https://www.w3.org/2025/01/aria-charter).
 
 ## Current work 
@@ -54,6 +52,8 @@ To learn about the group’s focus, scope and deliverables, see the [ARIA Workin
 For details of the current work, see the [ARIA Working Group README on GitHub](https://github.com/w3c/aria/#readme).
 
 The ARIA Working Group follows a set process for developing ARIA guidelines and resolving ARIA issues &mdash; for details, see [ARIA Working Group Process Document](https://github.com/w3c/aria/blob/main/documentation/process.md).
+
+For more information, see [WAI-ARIA Overview](https://www.w3.org/WAI/standards-guidelines/aria/).
 
 ### WAI-ARIA
 
@@ -85,13 +85,13 @@ The [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/) describes
 
 ## Contribute to the work
 
-W3C and the ARIA Working Group welcome input on ARIA work from the global accessibility community.
+W3C and the ARIA Working Group welcome input on ARIA work from individuals and organizations around the world.
 
 ### Contribute without joining the group
 
 There are ways you can contribute without being a member of the working group:
 
-* **Comment on publications:** During development, the group publishes working drafts for public comment &mdash; these are announced on the [WAI News pages](/news/) and on the [WAI Interest Group mailing lists](/about/groups/waiig/#mailinglist).
+* **Comment on publications:** During development, the group publishes working drafts for public comment &mdash; to be notified about draft documents for review, [subscribe to WAI news](https://www.w3.org/WAI/news/subscribe/).
 * **Raise, comment on, or propose fixes to ARIA issues:** If you’re aware of an issue with any of the published ARIA resources, W3C welcomes you to raise a new issue on GitHub, or you can also comment on and, even better, propose solutions for existing issues &mdash; see the list of [repositories maintained by the ARIA Working Group below](#github-repositories).
 * **Contribute to ARIA discussions:** You may contribute your views to the ARIA Working Group's [open ARIA discussions in GitHub](https://github.com/w3c/aria/discussions) and [mailing list discussions](https://lists.w3.org/Archives/Public/public-aria/).
 
@@ -107,7 +107,7 @@ Being a participant involves commitment to support the work of the group in the 
 
 See [Instructions for joining the Accessible Rich Internet Applications Working Group](https://www.w3.org/groups/wg/aria/instructions/).
 
-## Group members and task forces
+## Group participants and task forces
 
 * [Chairs](https://www.w3.org/groups/wg/aria/participants/#chairs)
 * [Current participants](https://www.w3.org/groups/wg/aria/participants/#participants)
@@ -147,7 +147,6 @@ The ARIA Working Group maintains the following GitHub repositories:
 W3C maintains a public list of any patent disclosures made in connection with the deliverables of the group &mdash; for details, see [Intellectual property rights &mdash; ARIA Working Group](https://www.w3.org/groups/wg/aria/ipr/).
 
 There are also instructions for [How to Make a Patent Disclosure](https://www.w3.org/groups/wg/aria/ipr/#discl-howto).
-
 
 ## Contact the chairs
 

--- a/pages/about/groups/ariawg.md
+++ b/pages/about/groups/ariawg.md
@@ -91,7 +91,7 @@ W3C and the ARIA Working Group welcome input on ARIA work from individuals and o
 
 There are ways you can contribute without being a member of the working group:
 
-* **Comment on publications:** During development, the group publishes working drafts for public comment &mdash; to be notified about draft documents for review, [subscribe to WAI news](https:///news/subscribe/).
+* **Comment on publications:** During development, the group publishes working drafts for public comment &mdash; to be notified about draft documents for review, [subscribe to WAI news](/news/subscribe/).
 * **Raise, comment on, or propose fixes to ARIA issues:** If you’re aware of an issue with any of the published ARIA resources, W3C welcomes you to raise a new issue on GitHub, or you can also comment on and, even better, propose solutions for existing issues &mdash; see the list of [repositories maintained by the ARIA Working Group below](#github-repositories).
 * **Contribute to ARIA discussions:** You may contribute your views to the ARIA Working Group's [open ARIA discussions in GitHub](https://github.com/w3c/aria/discussions) and [mailing list discussions](https://lists.w3.org/Archives/Public/public-aria/).
 

--- a/pages/about/groups/ariawg.md
+++ b/pages/about/groups/ariawg.md
@@ -91,7 +91,7 @@ W3C and the ARIA Working Group welcome input on ARIA work from individuals and o
 
 There are ways you can contribute without being a member of the working group:
 
-* **Comment on publications:** During development, the group publishes working drafts for public comment &mdash; to be notified about draft documents for review, [subscribe to WAI news](https://www.w3.org/WAI/news/subscribe/).
+* **Comment on publications:** During development, the group publishes working drafts for public comment &mdash; to be notified about draft documents for review, [subscribe to WAI news](https:///news/subscribe/).
 * **Raise, comment on, or propose fixes to ARIA issues:** If you’re aware of an issue with any of the published ARIA resources, W3C welcomes you to raise a new issue on GitHub, or you can also comment on and, even better, propose solutions for existing issues &mdash; see the list of [repositories maintained by the ARIA Working Group below](#github-repositories).
 * **Contribute to ARIA discussions:** You may contribute your views to the ARIA Working Group's [open ARIA discussions in GitHub](https://github.com/w3c/aria/discussions) and [mailing list discussions](https://lists.w3.org/Archives/Public/public-aria/).
 

--- a/pages/about/groups/ig.md
+++ b/pages/about/groups/ig.md
@@ -60,9 +60,9 @@ If you want to send a message to this list, you must send it from an email addre
 
 **Note:** Emails to the Announcement List will also go to the Discussion List.
 
-#### Subscribe or unsubscribe to the Announcements List
+#### Subscribe to or unsubscribe from the Announcements List
 
-* To **subscribe**, send an email to with the subject line ‘Subscribe’ to [public-wai-announce-request@w3.org](mailto:public-wai-announce-request@w3.org?subject=subscribe).
+* To **subscribe**, send an email with the subject line ‘Subscribe’ to [public-wai-announce-request@w3.org](mailto:public-wai-announce-request@w3.org?subject=subscribe).
 * To **unsubscribe**, send an email with the subject line ‘Unsubscribe’ to [public-wai-announce-request@w3.org](mailto:public-wai-announce-request@w3.org?subject=unsubscribe).
 
 ### Discussion List

--- a/pages/about/groups/index.md
+++ b/pages/about/groups/index.md
@@ -14,9 +14,9 @@ The Web Accessibility Initiative (WAI)’s working groups develop digital access
 
 ## Accessibility Guidelines Working Group
 
-The mission of the [Accessibility Guidelines (AG) Working Group](/about/groups/agwg/) and its task forces is to develop and maintain specifications for making web content accessible to people with disabilities, along with support materials for implementing the Web Content Accessibility Guidelines (WCAG).
+The mission of the [Accessibility Guidelines (AG) Working Group](/about/groups/agwg/) is to develop and maintain specifications for making web content accessible to people with disabilities, along with support materials for implementing the Web Content Accessibility Guidelines (WCAG).
 
-The AG Working Group is supported by the:
+The AG Working Group includes the:
 
  - [Accessibility Conformance Testing Task Force](/about/groups/task-forces/conformance-testing/)
  - [Cognitive and Learning Disabilities Accessibility Task Force](/about/groups/task-forces/coga/)
@@ -27,9 +27,9 @@ The AG Working Group is supported by the:
 
 ## Accessible Platform Architectures Working Group
 
-The mission of the [Accessible Platform Architectures (APA) Working Group](/about/groups/apawg/) and its task forces is to ensure W3C specifications support accessibility for people with disabilities through the following activities: reviewing specifications; developing new specifications and technical support materials; collaborating with other W3C working groups on technology accessibility; and coordinating harmonized accessibility strategies within W3C that include security, privacy, and internationalization.
+The mission of the [Accessible Platform Architectures (APA) Working Group](/about/groups/apawg/) is to ensure W3C specifications support accessibility for people with disabilities through the following activities: reviewing specifications; developing new specifications and technical support materials; collaborating with other W3C working groups on technology accessibility; and coordinating harmonized accessibility strategies within W3C that include security, privacy, and internationalization.
 
-The APA Working Group is supported by the:
+The APA Working Group includes the:
 
  - [Framework for Accessible Specification of Technologies Task Force](/about/groups/task-forces/fast/)
  - [Maturity Model Task Force](/about/groups/task-forces/maturity-model/)
@@ -39,9 +39,9 @@ The APA Working Group is supported by the:
 
 ## ARIA Working Group
 
-The mission of the [Accessible Rich Internet Applications (ARIA) Working Group](/about/groups/ariawg/) and its task forces is to enhance the accessibility of web content through developing supplemental attributes that can be applied to native host language interactive elements and exposed via platform accessibility application programming interfaces (APIs).
+The mission of the [Accessible Rich Internet Applications (ARIA) Working Group](/about/groups/ariawg/) is to enhance the accessibility of web content through developing supplemental attributes that can be applied to native host language interactive elements and exposed via platform accessibility application programming interfaces (APIs).
 
-The ARIA Working Group is supported by the:
+The ARIA Working Group includes the:
 
  - [Authoring Practices Guide Task Force](/about/groups/task-forces/practices/)
  - [Portable Document Format Accessibility APIs Mapping Task Force](/about/groups/task-forces/pdf-aam/)
@@ -50,6 +50,6 @@ The ARIA Working Group is supported by the:
 
 The [WAI Interest Group](/about/groups/waiig/) is a public forum with mailing lists for sharing information and exchanging ideas about W3C’s digital accessibility work.
 
-## Previous groups
+## Past groups
 
-See details for [closed working groups and task forces](/about/groups/previous-groups/).
+See [Past groups](/about/groups/previous-groups/) for details of working groups and task forces that have now closed.

--- a/pages/about/groups/past-groups.md
+++ b/pages/about/groups/past-groups.md
@@ -1,6 +1,6 @@
 ---
-title: Previous groups
-nav_title: 'Previous groups'
+title: Past groups
+nav_title: 'Past groups'
 lang: en
 permalink: /about/groups/previous-groups/
 ref: /about/groups/previous-groups/
@@ -31,7 +31,7 @@ See details for working groups and task forces that have now closed.
 {% include_cached toc.html type="end" %}
 {:/}
 
-## Previous working groups
+## Past working groups
 
 * [Authoring Tool Accessibility Working Group](https://www.w3.org/groups/wg/atag/) &mdash; group closed in 2015
 * [Education and Outreach Working Group](https://www.w3.org/groups/wg/eowg/) &mdash; group closed in 2024
@@ -39,8 +39,7 @@ See details for working groups and task forces that have now closed.
 * [Research and Development Working Group](https://www.w3.org/groups/wg/wai-rd/) &mdash; group closed in 2015
 * [User Agent Accessibility Working Group](https://www.w3.org/groups/wg/uaag/) &mdash; group closed in 2016
 
-## Previous task forces
+## Past task forces
 
-* [CSS Accessibility Task Force](https://www.w3.org/groups/tf/css-a11y/)
-* [Silver Task Force](https://www.w3.org/groups/tf/silver-tf/)
-
+* [CSS Accessibility Task Force](https://www.w3.org/groups/tf/css-a11y/) &mdash; group closed in 2021
+* [Silver Task Force](https://www.w3.org/groups/tf/silver-tf/) &mdash; group closed in 2023

--- a/pages/about/groups/task-forces/adapt.md
+++ b/pages/about/groups/task-forces/adapt.md
@@ -34,16 +34,11 @@ Find out about the activities of the WAI-Adapt Task Force and how you can contri
 
 ## Objectives
 
-The objective of the WAI-Adapt Task Force is to develop normative specifications and best practices guidance to support enhanced and personalized web content delivery that better meets the diverse requirements of people with disabilities — it does this by making fuller use of underused features already specified in HTML, and by proposing new markup elements and attributes, as needed.
+The WAI-Adapt Task Force develops normative specifications and best practices guidance to support enhanced and personalized web content delivery that better meets the diverse requirements of people with disabilities. It does this by making fuller use of underused features already specified in HTML, and by proposing new markup elements and attributes, as needed.
 
 ## Work statement
 
 To learn about the focus, scope and deliverables of the task force, see the [WAI-Adapt Task Force Work Statement](/about/groups/task-forces/adapt/work-statement/).
-
-## Overview of the WAI-Adapt work
-
-* [WAI-Adapt Overview](https://www.w3.org/WAI/adapt/) &mdash; an overview of W3C’s WAI-Adapt technique
-* [WAI-Adapt video {% include_cached external.html %}](https://ln.sync.com/dl/04f8c9330/) &mdash; a technical demonstration of a semantic overlay approach that enables user-driven personalization, employing user-preferred symbols for text that has had WAI-Adapt semantics added to it
 
 ## Current work
 
@@ -51,16 +46,24 @@ The WAI-Adapt Task Force supports the deliverables of the [Accessible Platform A
 
 For details of the current work, see the [WAI-Adapt Task Force wiki](https://github.com/w3c/adapt/wiki).
 
+For more information on the WAI-Adapt work, see:
+
+* [WAI-Adapt Overview](https://www.w3.org/WAI/adapt/) &mdash; an overview of W3C’s WAI-Adapt technique
+* [WAI-Adapt video {% include_cached external.html %}](https://ln.sync.com/dl/04f8c9330/) &mdash; a technical demonstration of a semantic overlay approach that enables user-driven personalization, employing user-preferred symbols for text that has had WAI-Adapt semantics added to it
+
 ## Contribute to the work
 
-The WAI-Adapt Task Force welcomes input from the global accessibility community on the work to enable content and interface personalization for people with cognitive and learning disabilities.
+The WAI-Adapt Task Force welcomes input from individuals and organizations around the world on the work to enable content and interface personalization for people with cognitive and learning disabilities.
 
 ### Contribute without joining the task force
 
-You can contribute to the work without being a member of the task force in the [WAI-Adapt GitHub repository](https://github.com/w3c/adapt/issues):
+You can contribute to the work without being a member of the task force:
 
-* If you’re aware of an issue with any of the published WAI-Adapt resources, raise a new issue.
-* Comment on or propose solutions for open WAI-Adapt issues.
+- **Draft WAI-Adapt resources:** Review and provide feedback on drafts that are still being developed.
+- **Open WAI-Adapt issues:** Comment on or propose solutions for open issues.
+- **Published WAI-Adapt resources:** Let us know if there is a new issue with any of these.
+
+Either comment / raise a new issue in the [WAI-Adapt GitHub repository](https://github.com/w3c/adapt/issues) or email the [chair](https://www.w3.org/groups/tf/personalization-tf/participants/#chairs).
 
 ### Become a participant in the task force
 
@@ -78,7 +81,7 @@ Once you are a member of the APA Working Group, email the [W3C staff contact for
 
 **Note:** As a participant in one of the APA Working Group’s task forces, you can choose to focus your time exclusively on the task force deliverables and you do not have to contribute to the working group’s other activities.
 
-## Task force members
+## Task force participants
 
 * [Chair](https://www.w3.org/groups/tf/personalization-tf/participants/#chairs)
 * [Current participants](https://www.w3.org/groups/tf/personalization-tf/participants/#participants)
@@ -93,11 +96,11 @@ Once you are a member of the APA Working Group, email the [W3C staff contact for
 
 The WAI-Adapt Task Force develops and maintains the following resources for the APA Working Group:
 
-* [Requirements for WAI-Adapt specification &mdash; 2022 Group Draft Note](https://www.w3.org/TR/adapt-requirements/) &mdash; user stories, specific use cases, and requirements for WAI-Adapt
-* [WAI-Adapt: Tools Module &mdash; 2022 Group Draft Note]() &mdash; examples of the personalized tools properties
-* [WAI-Adapt: Help and Support Module &mdash; 2022 Working Draft](https://www.w3.org/TR/adapt-help/) &mdash; examples of the personalized help and support properties
-* [WAI-Adapt: Symbols Module &mdash; 2023 Candidate Recommendation Snapshot](https://www.w3.org/TR/adapt-symbols/) &mdash; technical specification providing terms authors can use to enhance web content with information about controls, symbols, and user interface elements
-* [WAI-Adapt Explainer &mdash; 2023 Group Draft Note](https://www.w3.org/TR/adapt/) &mdash; introductory document explaining general use cases, vocabulary, and anticipated uses
+* [WAI-Adapt Explainer &mdash; Group Draft Note](https://www.w3.org/TR/adapt/) (and latest [Editor’s Draft](https://w3c.github.io/adapt/)) &mdash; introductory document explaining general use cases, vocabulary, and anticipated uses
+* [WAI-Adapt: Tools Module &mdash; Working Draft](https://www.w3.org/TR/adapt-tools/) (and latest [Editor’s Draft](https://w3c.github.io/adapt/tools/))
+* [WAI-Adapt: Symbols Module &mdash; Candidate Recommendation Snapshot](https://www.w3.org/TR/adapt-symbols/) (and latest [Editor’s Draft](https://w3c.github.io/adapt/symbols/)) &mdash; technical specification providing terms authors can use to enhance web content with information about controls, symbols, and user interface elements
+* [WAI-Adapt: Help and Support Module &mdash; Working Draft](https://www.w3.org/TR/adapt-help/) (and latest [Editor’s Draft](https://w3c.github.io/adapt/help/)) &mdash; examples of the personalized help and support properties
+* [Requirements for WAI-Adapt specification &mdash; Group Draft Note](https://www.w3.org/TR/adapt-requirements/) (and latest [Editor’s Draft](https://w3c.github.io/adapt/requirements/) &mdash; user stories, specific use cases, and requirements for WAI-Adapt
 
 ## Contact the chair
 

--- a/pages/about/groups/task-forces/adapt.md
+++ b/pages/about/groups/task-forces/adapt.md
@@ -48,7 +48,7 @@ For details of the current work, see the [WAI-Adapt Task Force wiki](https://git
 
 For more information on the WAI-Adapt work, see:
 
-* [WAI-Adapt Overview](https://www.w3.org/WAI/adapt/) &mdash; an overview of W3C’s WAI-Adapt technique
+* [WAI-Adapt Overview](/adapt/) &mdash; an overview of W3C’s WAI-Adapt technique
 * [WAI-Adapt video {% include_cached external.html %}](https://ln.sync.com/dl/04f8c9330/) &mdash; a technical demonstration of a semantic overlay approach that enables user-driven personalization, employing user-preferred symbols for text that has had WAI-Adapt semantics added to it
 
 ## Contribute to the work

--- a/pages/about/groups/task-forces/coga.md
+++ b/pages/about/groups/task-forces/coga.md
@@ -47,7 +47,7 @@ The COGA Task Force supports the deliverables of two W3C working groups:
 
 For details of the current work, see the [COGA Task Force wiki](https://www.w3.org/WAI/GL/task-forces/coga/wiki).
 
-For more information, see [Cognitive Accessibility at W3C](https://www.w3.org/WAI/cognitive/).
+For more information, see [Cognitive Accessibility at W3C](/cognitive/).
 
 ## Contribute to the work
 

--- a/pages/about/groups/task-forces/coga.md
+++ b/pages/about/groups/task-forces/coga.md
@@ -32,7 +32,7 @@ Find out about the activities of the Cognitive and Learning Disabilities Accessi
 
 ## Objectives
 
-The objective of the COGA Task Force is to develop guidance and techniques for content authoring and user agent implementation in order to make web content accessible to people with cognitive and learning disabilities.
+The COGA Task Force develops guidance and techniques for content authoring and user agent implementation in order to make web content accessible to people with cognitive and learning disabilities.
 
 ## Work statement
 
@@ -47,15 +47,21 @@ The COGA Task Force supports the deliverables of two W3C working groups:
 
 For details of the current work, see the [COGA Task Force wiki](https://www.w3.org/WAI/GL/task-forces/coga/wiki).
 
+For more information, see [Cognitive Accessibility at W3C](https://www.w3.org/WAI/cognitive/).
+
 ## Contribute to the work
 
-The COGA Task Force welcomes input from the global accessibility community on cognitive and learning accessibility work.
+The COGA Task Force welcomes input from individuals and organizations around the world on the cognitive and learning accessibility work.
 
 ### Contribute without joining the task force
 
-You can contribute to the work without being a member of the task force in the [COGA GitHub repository](https://github.com/w3c/coga/issues):
-* If you’re aware of an issue with any of the published COGA resources, raise a new issue.
-* Comment on or propose solutions for open COGA issues.
+You can contribute to the work without being a member of the task force:
+
+- **Draft COGA resources:** Review and provide feedback on drafts that are still being developed.
+- **Open COGA issues:** Comment on or propose solutions for open issues.
+- **Published COGA resources:** Let us know if there is a new issue with any of these.
+
+Either comment / raise a new issue in the [COGA GitHub repository](https://github.com/w3c/coga/issues) or email the [chair](https://www.w3.org/groups/tf/cognitive-a11y-tf/participants/#chairs).
 
 ### Become a participant in the task force
 
@@ -75,7 +81,7 @@ Once you are a member of either the AG or APA working groups, email the [W3C sta
 
 **Note:** As a participant in one of the AG or APA working groups’ task forces, you can choose to focus your time exclusively on the task force deliverables and you do not have to contribute to the working group’s other activities.
 
-## Task force members
+## Task force participants
 
 * [Chair](https://www.w3.org/groups/tf/cognitive-a11y-tf/participants/#chairs)
 * [Current participants](https://www.w3.org/groups/tf/cognitive-a11y-tf/participants/#participants)
@@ -90,13 +96,11 @@ Once you are a member of either the AG or APA working groups, email the [W3C sta
 
 The COGA Task Force has developed the following resources for the AG and APA working groups:
 
-* [Cognitive Accessibility Guidance](https://www.w3.org/WAI/WCAG2/supplemental/#cognitiveaccessibilityguidance)
-* [Cognitive Accessibility User Research &mdash; 2015 Working Draft](https://w3c.github.io/coga/user-research/)
-* [Cognitive Accessibility User Research &mdash; 2024 Editor’s Draft](https://www.w3.org/TR/coga-user-research/)
-* [Making Content Usable for People with Cognitive and Learning Disabilities &mdash; 2018 Working Draft](https://www.w3.org/TR/2018/WD-coga-usable-20181211/)
-* [Making Content Usable for People with Cognitive and Learning Disabilities &mdash; 2021 Working Group Note](https://www.w3.org/TR/coga-usable/)
-* [Cognitive Accessibility Roadmap and Gap Analysis &mdash; 2024 Working Draft](https://w3c.github.io/coga/gap-analysis/)
-* [Cognitive Accessibility Issue &mdash; 2024 Editor’s Draft](https://w3c.github.io/coga/issue-papers/)
+* [Cognitive Accessibility Supplemental Guidance](https://www.w3.org/WAI/WCAG2/supplemental/#cognitiveaccessibilityguidance)
+* [Cognitive Accessibility User Research &mdash; Working Draft](https://www.w3.org/TR/2015/WD-coga-user-research-20150115/) (and latest [Editor’s Draft](https://w3c.github.io/coga/user-research/))
+* [Making Content Usable for People with Cognitive and Learning Disabilities &mdash; Working Group Note](https://www.w3.org/TR/coga-usable/) (and latest [Editor’s Draft](https://w3c.github.io/coga/content-usable/))
+* [Cognitive Accessibility Roadmap and Gap Analysis &mdash; Working Draft](https://www.w3.org/TR/coga-gap-analysis/) (and latest [Editor’s Draft](https://w3c.github.io/coga/gap-analysis/))
+* [Cognitive Accessibility Issue Papers &mdash; Editor’s Draft](https://w3c.github.io/coga/issue-papers/)
 
 ## Contact the chair
 

--- a/pages/about/groups/task-forces/conformance-testing.md
+++ b/pages/about/groups/task-forces/conformance-testing.md
@@ -32,7 +32,7 @@ Find out about the activities of the Accessibility Conformance Testing (ACT) Tas
 
 ## Objectives
 
-The objective of the ACT Task Force is to develop and maintain a repository of ACT Rules for WCAG 2 in order to promote a unified interpretation across different web accessibility test tools and methodologies.
+The ACT Task Force develops and maintains a repository of ACT Rules for WCAG 2 in order to promote a unified interpretation across different web accessibility test tools and methodologies.
 
 ## Work statement
 
@@ -44,15 +44,21 @@ The ACT Task Force supports the deliverables of the [Accessibility Guidelines (A
 
 For details of the current work, see the [ACT Task Force wiki](https://www.w3.org/WAI/GL/task-forces/conformance-testing/wiki/).
 
+For more information, see [ACT Overview](/standards-guidelines/act/).
+
 ## Contribute to the work
 
-The ACT Task Force welcomes input from the global accessibility community on the ACT Rules work.
+The ACT Task Force welcomes input from individuals and organizations around the world on the ACT Rules work.
 
 ### Contribute without joining the task force
 
-You can contribute to the work without being a member of the task force in the [ACT GitHub repository](https://github.com/w3c/wcag-act/issues/):
-* If you’re aware of an issue with any of the published ACT resources, raise a new issue.
-* Comment on or propose solutions for open ACT issues.
+You can contribute to the work without being a member of the task force:
+
+- **Draft ACT resources:** Review and provide feedback on drafts that are still being developed.
+- **Open ACT issues:** Comment on or propose solutions for open issues.
+- **Published ACT resources:** Let us know if there is a new issue with any of these.
+
+Either comment / raise a new issue in the [ACT GitHub repository](https://github.com/w3c/wcag-act/issues/) or email the [chairs](https://www.w3.org/groups/tf/wcag-act/participants/#chairs).
 
 ### Become a participant in the task force
 
@@ -70,7 +76,7 @@ Once you are a member of the AG Working Group, email the [W3C Staff Contact for 
 
 **Note:** As a participant in one of the AG Working Group’s task forces, you can choose to focus your time exclusively on the task force deliverables and you do not have to contribute to the working group’s other activities.
 
-## Task force members
+## Task force participants
 
 * [Chairs](https://www.w3.org/groups/tf/wcag-act/participants/#chairs)
 * [Current participants](https://www.w3.org/groups/tf/wcag-act/participants/#participants)
@@ -85,9 +91,7 @@ Once you are a member of the AG Working Group, email the [W3C Staff Contact for 
 
 The ACT Task Force develops and maintains the following resources for the AG Working Group:
 
-* [Accessibility Conformance Testing (ACT) Rules Format 1.0 — 2019 W3C Recommendation](https://www.w3.org/TR/act-rules-format/)
-* [Accessibility Conformance Testing (ACT) Rules Format 1.1 — 2024 First Public Working Draft](https://www.w3.org/TR/act-rules-format-1.1/)
-* [ Accessibility Conformance Testing (ACT) Rules Format 1.1 — 2024 Editor’s Draft](https://w3c.github.io/wcag-act/act-rules-format.html)
+* [Accessibility Conformance Testing (ACT) Rules Format 1.1 — Working Draft](https://www.w3.org/TR/act-rules-format-1.1/) (and latest [Editor’s Draft](https://w3c.github.io/wcag-act/act-rules-format.html))
 * [Repository of published Accessibility Conformance Testing (ACT) Rules](https://www.w3.org/WAI/standards-guidelines/act/rules/)
 
 ## Contact the chairs

--- a/pages/about/groups/task-forces/fast.md
+++ b/pages/about/groups/task-forces/fast.md
@@ -32,7 +32,11 @@ Find out about the activities of the Framework for Accessible Specification of T
 
 ## Objectives
 
-The objectives of the FAST Task Force are to develop and maintain inventories of user and functional needs; best practices guidance describing the features that web technologies should provide to ensure accessible content can be created; and the self-assessment tool used by W3C working groups during W3C’s accessibility horizontal review process.
+The FAST Task Force develops and maintains:
+
+- inventories of user and functional needs,
+- best practices guidance describing the features that web technologies should provide to ensure accessible content can be created, and 
+- the self-assessment tool used by W3C working groups during W3C’s accessibility horizontal review process.
 
 ## Work statement
 
@@ -46,13 +50,17 @@ For details of the current work, see the [FAST GitHub repository](https://github
 
 ## Contribute to the work
 
-The FAST Task Force welcomes input from the global accessibility community on the FAST work.
+The FAST Task Force welcomes input from individuals and organizations around the world on the FAST work.
 
 ### Contribute without joining the task force
 
-You can contribute to the work without being a member of the task force in the [FAST GitHub repository](https://github.com/w3c/fast/issues):
-* If you’re aware of an issue with any of the published FAST resources, raise a new issue.
-* Comment on or propose solutions for open FAST issues.
+You can contribute to the work without being a member of the task force:
+
+- **Draft FAST resources:** Review and provide feedback on drafts that are still being developed.
+- **Open FAST issues:** Comment on or propose solutions for open issues.
+- **Published FAST resources:** Let us know if there is a new issue with any of these.
+
+Either comment / raise a new issue in the [FAST GitHub repository](https://github.com/w3c/fast/issues) or email the [chairs](https://www.w3.org/groups/tf/fast/participants/#chairs).
 
 ### Become a participant in the task force
 
@@ -70,7 +78,7 @@ Once you are a member of the APA Working Group, email the [W3C Staff Contact for
 
 **Note:** As a participant in one of the APA Working Group’s task forces, you can choose to focus your time exclusively on the task force deliverables and you do not have to contribute to the working group’s other activities.
 
-## Task force members
+## Task force participants
 
 * [Chairs](https://www.w3.org/groups/tf/fast/participants/#chairs)
 * [Current participants](https://www.w3.org/groups/tf/fast/participants/#participants)
@@ -85,7 +93,7 @@ Once you are a member of the APA Working Group, email the [W3C Staff Contact for
 
 The FAST Task Force develops and maintains the following resources for the APA Working Group:
 
-* [Framework for Accessible Specification of Technologies (FAST) &mdash; 2024 Editor’s Draft](https://www.w3.org/TR/act-rules-format/)
+* [Framework for Accessible Specification of Technologies (FAST) &mdash; Editor’s Draft](https://w3c.github.io/fast/)
 * [FAST Report Tool](https://fast-rose.vercel.app/) &mdash; a checklist for reviewing technologies
 
 ## Contact the chairs

--- a/pages/about/groups/task-forces/low-vision-a11y-tf.md
+++ b/pages/about/groups/task-forces/low-vision-a11y-tf.md
@@ -32,7 +32,11 @@ Find out about the activities of the Low Vision Accessibility (LV) Task Force an
 
 ## Objectives
 
-The objective of the LV Task Force is to address web accessibility issues that are specific to people with low vision through inputting into WCAG 2 techniques and understanding documents; inputting into WCAG 3; and developing additional low-vision guidance resources.
+The LV Task Force addresses web accessibility issues that are specific to people with low vision through: 
+
+- inputting into WCAG 2 techniques and understanding documents,
+- inputting into WCAG 3, and 
+- developing additional low-vision guidance resources.
 
 ## Work statement
 
@@ -48,7 +52,7 @@ For details of the work, see the [LV Task Force wiki](https://www.w3.org/WAI/GL/
 
 ## Contribute to the work
 
-The LV Task Force welcomes input from the global accessibility community on the low vision accessibility work.
+The LV Task Force welcomes input from individuals and organizations around the world on the low vision accessibility work.
 
 ### Contribute without joining the task force
 
@@ -60,7 +64,7 @@ If you’re aware of an issue with any of the published low vision accessibility
 
 Details of how to join the LV Task Force will be published here when it is reactivated.
 
-## Task force members
+## Task force participants
 
 * [Chairs](https://www.w3.org/groups/tf/low-vision-a11y-tf/participants/#chairs)
 * [Current participants](https://www.w3.org/groups/tf/low-vision-a11y-tf/participants/#participants)
@@ -73,10 +77,7 @@ Details of how to join the LV Task Force will be published here when it is react
 
 ## Publications
 
-The LV Task Force develops and maintains the following resources for the AG Working Group:
-
-* [Accessibility Requirements for People with Low Vision — 2016 First Public Working Draft](https://www.w3.org/TR/low-vision-needs/)
-* [Accessibility Requirements for People with Low Vision — 2023 Editor’s Draft](https://w3c.github.io/low-vision-a11y-tf/requirements.html)
+The LV Task Force develops and maintains the following resource for the AG Working Group: [Accessibility Requirements for People with Low Vision — Working Draft](https://www.w3.org/TR/low-vision-needs/) (and latest [Editor’s Draft](https://w3c.github.io/low-vision-a11y-tf/requirements.html)).
 
 ## Contact the chairs
 

--- a/pages/about/groups/task-forces/matf.md
+++ b/pages/about/groups/task-forces/matf.md
@@ -49,7 +49,7 @@ The Mobile Accessibility Task Force supports the deliverables of the [Accessibil
 
 For details of the current work, see the [Mobile Accessibility Task Force GitHub repository](https://github.com/w3c/matf/issues).
 
-For more information, see [Mobile Accessibility at W3C](https://www.w3.org/WAI/standards-guidelines/mobile/).
+For more information, see [Mobile Accessibility at W3C](/standards-guidelines/mobile/).
 
 ## Contribute to the work
 

--- a/pages/about/groups/task-forces/matf.md
+++ b/pages/about/groups/task-forces/matf.md
@@ -11,7 +11,7 @@ github:
 {% include box.html type="start" title="Summary" class="" %}
 {:/}
 
-Find out about the activities of the Mobile Accessibility (Mobile A11y) Task Force and how you can contribute to its objectives.
+Find out about the activities of the Mobile Accessibility Task Force and how you can contribute to its objectives.
 
 {::nomarkdown}
 {% include box.html type="end" %}
@@ -32,31 +32,42 @@ Find out about the activities of the Mobile Accessibility (Mobile A11y) Task For
 
 ## Objectives
 
-The objectives of the Mobile A11y Task Force are to produce resources for how to apply the Web Content Accessibility Guidelines (WCAG) to mobile — including, but not limited to, native mobile apps; mobile web apps; mobile web content; and hybrid apps that use web components inside native mobile apps — and to make sure mobile apps are considered in new accessibility guidelines.
+The Mobile Accessibility Task Force:
+
+- produces resources for how to apply the Web Content Accessibility Guidelines (WCAG) to mobile, and 
+- makes sure mobile apps are considered in new accessibility guidelines.
+
+Mobile includes, but is not limited to, native mobile apps, mobile web apps, and hybrid apps that use web components inside native mobile apps.
 
 ## Work statement
 
-The Mobile A11y Task Force has regrouped in 2024 and a new Work Statement will be published soon.
+To learn about the focus, scope and deliverables of the task force, see the [Mobile Accessibility Task Force Work Statement](/about/groups/task-forces/matf/work-statement/).
 
 ## Current work
 
-The Mobile A11y Task Force supports the deliverables of the [Accessibility Guidelines (AG) Working Group](/about/groups/agwg/).
+The Mobile Accessibility Task Force supports the deliverables of the [Accessibility Guidelines (AG) Working Group](/about/groups/agwg/).
 
-For details of the current work, see the [Mobile A11y Task Force GitHub repository](https://github.com/w3c/matf/issues).
+For details of the current work, see the [Mobile Accessibility Task Force GitHub repository](https://github.com/w3c/matf/issues).
+
+For more information, see [Mobile Accessibility at W3C](https://www.w3.org/WAI/standards-guidelines/mobile/).
 
 ## Contribute to the work
 
-The Mobile A11y Task Force welcomes input from the global accessibility community on mobile accessibility work.
+The Mobile Accessibility Task Force welcomes input from individuals and organizations around the world on the mobile accessibility work.
 
 ### Contribute without joining the task force
 
-You can contribute to the work without being a member of the task force in the [Mobile A11y GitHub repository](https://github.com/w3c/matf/):
-* If you’re aware of an issue with any of the published mobile accessibility resources, raise a new issue.
-* Comment on or propose solutions for open mobile accessibility issues.
+You can contribute to the work without being a member of the task force:
+
+- **Draft mobile accessibility resources:** Review and provide feedback on drafts that are still being developed.
+- **Open mobile accessibility issues:** Comment on or propose solutions for open issues.
+- **Published mobile accessibility resources:** Let us know if there is a new issue with any of these.
+
+Either comment / raise a new issue in the [Mobile Accessibility GitHub repository](https://github.com/w3c/matf/issues) or email the [chair](https://www.w3.org/groups/tf/mobile-a11y-tf/participants/#chairs).
 
 ### Become a participant in the task force
 
-Joining the Mobile A11y Task Force enables you to participate fully in the development of the work and influence the deliverables. You and your organization will also be listed as contributors, where appropriate.
+Joining the Mobile Accessibility Task Force enables you to participate fully in the development of the work and influence the deliverables. You and your organization will also be listed as contributors, where appropriate.
 
 Being a participant involves commitment to support the work of the task force in the following ways:
 
@@ -64,13 +75,13 @@ Being a participant involves commitment to support the work of the task force in
 * Keep up with weekly tasks and the progress of the work &mdash; for example, via the minutes of past meetings, mailing list discussions, and GitHub issue comments.
 * Give your input promptly, when it’s needed.
 
-To become a participant in the Mobile A11y Task Force, you must first be a member of the AG Working Group. See [Instructions for joining the Accessibility Guidelines Working Group](https://www.w3.org/groups/wg/ag/instructions/).
+To become a participant in the Mobile Accessibility Task Force, you must first be a member of the AG Working Group. See [Instructions for joining the Accessibility Guidelines Working Group](https://www.w3.org/groups/wg/ag/instructions/).
 
-Once you are a member of the AG Working Group, email the [W3C Staff Contact for the Mobile A11y Task Force](https://www.w3.org/groups/tf/mobile-a11y-tf/participants/#staff) to let them know you’d like to join the task force.
+Once you are a member of the AG Working Group, email the [W3C Staff Contact for the Mobile Accessibility Task Force](https://www.w3.org/groups/tf/mobile-a11y-tf/participants/#staff) to let them know you’d like to join the task force.
 
 **Note:** As a participant in one of the AG Working Group’s task forces, you can choose to focus your time exclusively on the task force deliverables and you do not have to contribute to the working group’s other activities.
 
-## Task force members
+## Task force participants
 
 * [Chair](https://www.w3.org/groups/tf/mobile-a11y-tf/participants/#chairs)
 * [Current participants](https://www.w3.org/groups/tf/mobile-a11y-tf/participants/#participants)
@@ -83,12 +94,11 @@ Once you are a member of the AG Working Group, email the [W3C Staff Contact for 
 
 ## Publications
 
-The Mobile A11y Task Force develops and maintains the following resources for the AG Working Group;
+The Mobile Accessibility Task Force develops and maintains the following resources for the AG Working Group:
 
-* [Mobile Accessibility: How WCAG 2.0 and Other W3C/WAI Guidelines Apply to Mobile &mdash; 2015 First Public Working Draft](https://www.w3.org/TR/mobile-accessibility-mapping/)
-* [Mobile Accessibility: How WCAG 2.0 and Other W3C/WAI Guidelines Apply to Mobile &mdash; 2018 Editor's Draft](https://w3c.github.io/Mobile-A11y-TF-Note/)
-* [Guidance on Applying WCAG 2.2 to Mobile (WCAG2Mobile) &mdash; 2024 Editor's Draft](https://w3c.github.io/matf/)
+* [Mobile Accessibility: How WCAG 2.0 and Other W3C/WAI Guidelines Apply to Mobile &mdash; Working Draft](https://www.w3.org/TR/mobile-accessibility-mapping/) (and latest [Editor’s Draft](https://w3c.github.io/Mobile-A11y-TF-Note/))
+* [Guidance on Applying WCAG 2.2 to Mobile Applications (WCAG2Mobile) &mdash; Editor's Draft](https://w3c.github.io/matf/)
 
 ## Contact the chair
 
-If you have a question for the Mobile A11y Task Force, email the [chair](https://www.w3.org/groups/tf/mobile-a11y-tf/participants/#chairs) or the [W3C staff contact](https://www.w3.org/groups/tf/mobile-a11y-tf/participants/#staff).
+If you have a question for the Mobile Accessibility Task Force, email the [chair](https://www.w3.org/groups/tf/mobile-a11y-tf/participants/#chairs) or the [W3C staff contact](https://www.w3.org/groups/tf/mobile-a11y-tf/participants/#staff).

--- a/pages/about/groups/task-forces/maturity-model.md
+++ b/pages/about/groups/task-forces/maturity-model.md
@@ -11,7 +11,7 @@ github:
 {% include box.html type="start" title="Summary" class="" %}
 {:/}
 
-Find out about the activities of the Maturity Model (MM) Task Force and how you can contribute to its objectives.
+Find out about the activities of the Maturity Model Task Force and how you can contribute to its objectives.
 
 {::nomarkdown}
 {% include box.html type="end" %}
@@ -32,32 +32,38 @@ Find out about the activities of the Maturity Model (MM) Task Force and how you 
 
 ## Objectives
 
-The objective of the Maturity Model (MM) Task Force is to provide an Accessibility Maturity Model to guide organizations in developing the capability to buy, build or use accessible internal and external products and services, and to help them track changes and trends in providing these products and services over time.
+The Maturity Model Task Force provides an Accessibility Maturity Model to guide organizations in developing the capability to:
 
+- buy, build or use accessible internal and external digital assets, products and services, and
+- track changes and trends in providing these assets, products and services over time.
 
 ## Work statement
 
-To learn about the focus, scope and deliverables of the task force, see the [MM Task Force Work Statement](/about/groups/task-forces/maturity-model/work-statement/).
+To learn about the focus, scope and deliverables of the task force, see the [Maturity Model Task Force Work Statement](/about/groups/task-forces/maturity-model/work-statement/).
 
 ## Current work
 
-The MM Task Force supports the deliverables of the [Accessible Platform Architectures (APA) Working Group](/about/groups/apawg/).
+The Maturity Model Task Force supports the deliverables of the [Accessible Platform Architectures (APA) Working Group](/about/groups/apawg/).
 
 For details of the current work, see the [Maturity Model GitHub repository](https://github.com/w3c/maturity-model/).
 
 ## Contribute to the work
 
-The MM Task Force welcomes input from the global accessibility community on the Accessibility Maturity Model work.
+The Maturity Model Task Force welcomes input from individuals and organizations around the world on the Accessibility Maturity Model work.
 
 ### Contribute without joining the task force
 
-You can contribute to the work without being a member of the task force in the [Maturity Model GitHub repository](https://github.com/w3c/maturity-model/issues):
-* If you’re aware of an issue with any of the published Accessibility Maturity Model resources, raise a new issue.
-* Comment on or propose solutions for open Maturity Model issues.
+You can contribute to the work without being a member of the task force:
+
+- **Draft Accessibility Maturity Model resources:** Review and provide feedback on drafts that are still being developed.
+- **Open Accessibility Maturity Model issues:** Comment on or propose solutions for open issues.
+- **Published Accessibility Maturity Model resources:** Let us know if there is a new issue with any of these.
+
+Either comment / raise a new issue in the [Maturity Model GitHub repository](https://github.com/w3c/maturity-model/issues) or email the [chairs](https://www.w3.org/groups/tf/maturity/participants/#chairs).
 
 ### Become a participant in the task force
 
-Joining the MM Task Force enables you to participate fully in the development of the work and influence the deliverables. You and your organization will also be listed as contributors, where appropriate.
+Joining the Maturity Model Task Force enables you to participate fully in the development of the work and influence the deliverables. You and your organization will also be listed as contributors, where appropriate.
 
 Being a participant involves commitment to support the work of the task force in the following ways:
 
@@ -65,13 +71,13 @@ Being a participant involves commitment to support the work of the task force in
 * Keep up with weekly tasks and the progress of the work &mdash; for example, via the minutes of past meetings, mailing list discussions, and GitHub issue comments.
 * Give your input promptly, when it’s needed.
 
-To become a participant in the MM Task Force, you must first be a member of the APA Working Group &mdash; see [Instructions for joining the Accessible Platform Architectures Working Group](https://www.w3.org/groups/wg/apa/instructions/).
+To become a participant in the Maturity Model Task Force, you must first be a member of the APA Working Group &mdash; see [Instructions for joining the Accessible Platform Architectures Working Group](https://www.w3.org/groups/wg/apa/instructions/).
 
 Once you are a member of the APA Working Group, email the [W3C staff contact for the Maturity Model Task Force](https://www.w3.org/groups/tf/maturity/participants/#staff) to let them know you’d like to join the task force.
 
 **Note:** As a participant in one of the APA Working Group’s task forces, you can choose to focus your time exclusively on the task force deliverables and you do not have to contribute to the working group’s other activities.
 
-## Task force members
+## Task force participants
 
 * [Chairs](https://www.w3.org/groups/tf/maturity/participants/#chairs)
 * [Current participants](https://www.w3.org/groups/tf/maturity/participants/#participants)
@@ -84,11 +90,11 @@ Once you are a member of the APA Working Group, email the [W3C staff contact for
 
 ## Publications
 
-The MM Task Force develops and maintains the following resources for the APA Working Group:
+The Maturity Model Task Force develops and maintains the following resources for the APA Working Group:
 
 * [Accessibility Maturity Model &mdash; 2024 Group Draft Note](https://www.w3.org/TR/maturity-model/)
 * [Accessibility Maturity Model &mdash; 2025 Editor’s Draft](https://w3c.github.io/maturity-model/)
 
 ## Contact the chairs
 
-If you have a question for the MM Task Force, email the [chairs](https://www.w3.org/groups/tf/maturity/participants/#chairs) or the [W3C staff contact](https://www.w3.org/groups/tf/maturity/participants/#staff).
+If you have a question for the Maturity Model Task Force, email the [chairs](https://www.w3.org/groups/tf/maturity/participants/#chairs) or the [W3C staff contact](https://www.w3.org/groups/tf/maturity/participants/#staff).

--- a/pages/about/groups/task-forces/pdf-aam.md
+++ b/pages/about/groups/task-forces/pdf-aam.md
@@ -33,7 +33,7 @@ Find out about the activities of the Portable Document Format Accessibility Appl
 
 ## Objectives 
 
-The objective of the PDF-AAM Task Force is to specify how user agents should map accessibility semantics within the Portable Document Format specification.
+The PDF-AAM Task Force specifies how user agents should map accessibility semantics within the Portable Document Format specification.
 
 ## Work Statement
 
@@ -47,13 +47,17 @@ For details of the current work, see the [PDF-AAM GitHub repository](https://git
 
 ## Contribute to the work
 
-The PDF-AAM Task Force welcomes input from the global accessibility community on the PDF-AAM module.
+The PDF-AAM Task Force welcomes input from individuals and organizations around the world on the PDF-AAM module.
 
 ### Contribute without joining the task force
 
-You can contribute to the work without being a member of the task force in the [PDF-AAM GitHub repository](https://github.com/w3c/pdf-aam/issues):
-* If you’re aware of an issue with the PDF-AAM module, raise a new issue.
-* Comment on or propose solutions for open PDF-AAM issues.
+You can contribute to the work without being a member of the task force:
+
+- **Draft PDF-AAM resources:** Review and provide feedback on drafts that are still being developed.
+- **Open PDF-AAM issues:** Comment on or propose solutions for open issues.
+- **Published PDF-AAM resources** Let us know if there is a new issue with any of these.
+
+Either comment / raise a new issue in the [PDF-AAM GitHub repository](https://github.com/w3c/pdf-aam/issues) or email the [chairs](https://www.w3.org/groups/tf/pdf-aam/participants/#chairs).
 
 ### Become a participant in the task force
 
@@ -71,7 +75,7 @@ Once you are a member of the ARIA Working Group, email the [W3C Staff Contact fo
 
 **Note:** As a participant in one of the ARIA Working Group’s task forces, you can choose to focus your time exclusively on the task force deliverables and you do not have to contribute to the working group’s other activities.
 
-## Task force members
+## Task force participants
 
 * [Chairs](https://www.w3.org/groups/tf/pdf-aam/participants/#chairs)
 * [Current participants](https://www.w3.org/groups/tf/pdf-aam/participants/#participants)
@@ -84,7 +88,7 @@ Once you are a member of the ARIA Working Group, email the [W3C Staff Contact fo
 
 ## Publications
 
-The PDF-AAM Task Force will develop and maintain the [PDF Accessibility API Mappings &mdash; 2024 Editor’s Draft](https://w3c.github.io/pdf-aam/) for the ARIA Working Group.
+The PDF-AAM Task Force develops and maintains the [PDF Accessibility API Mappings &mdash; Editor’s Draft](https://w3c.github.io/pdf-aam/) for the ARIA Working Group.
 
 ## Contact the chairs
 

--- a/pages/about/groups/task-forces/practices.md
+++ b/pages/about/groups/task-forces/practices.md
@@ -32,7 +32,10 @@ Find out about the activities of the ARIA Authoring Practices Task Force (known 
 
 ## Objectives
 
-The objective of the APG Task Force is to develop the WAI-ARIA Authoring Practices Guide, which describes considerations that might not be evident to authors from the WAI-ARIA specification alone, and recommends approaches to make widgets, navigation, and behaviors accessible using WAI-ARIA roles, states, and properties.
+The APG Task Force develops the WAI-ARIA Authoring Practices Guide, which:
+
+- describes considerations that might not be evident to authors from the WAI-ARIA specification alone, and,
+-recommends approaches to make widgets, navigation, and behaviors accessible using WAI-ARIA roles, states, and properties.
 
 ## Work statement
 
@@ -49,13 +52,17 @@ For details of the current work, see the following:
 
 ## Contribute to the work
 
-The APG Task Force welcomes input from the global accessibility community on the ARIA Authoring Practices Guide.
+The APG Task Force welcomes input from individuals and organizations around the world on the ARIA Authoring Practices Guide.
 
 ### Contribute without joining the task force
 
-You can contribute to the work without being a member of the task force in the [APG GitHub repository](https://github.com/w3c/aria-practices/issues):
-* If you’re aware of an issue with any of the published APG resources, raise a new issue.
-* Comment on or propose solutions for open APG issues.
+You can contribute to the work without being a member of the task force:
+
+- **Draft WAI-ARIA Authoring Practices:** Review and provide feedback on drafts that are still being developed.
+- **Open WAI-ARIA Authoring Practices issues:** Comment on or propose solutions for open issues.
+- **Published WAI-ARIA Authoring Practices Guide:** Let us know if there is a new issue with any of the practices in the guide.
+
+Either comment / raise a new issue in the [APG GitHub repository](https://github.com/w3c/aria-practices/issues) or email the [chairs](https://www.w3.org/groups/tf/aria-practices/participants/#chairs).
 
 ### Become a participant in the task force
 
@@ -73,7 +80,7 @@ Once you are a member of the ARIA Working Group, email the [W3C Staff Contact fo
 
 **Note:** As a participant in one of the ARIA Working Group’s task forces, you can choose to focus your time exclusively on the task force deliverables and you do not have to contribute to the working group’s other activities.
 
-## Task force members
+## Task force participants
 
 * [Chairs](https://www.w3.org/groups/tf/aria-practices/participants/#chairs)
 * [Current participants](https://www.w3.org/groups/tf/aria-practices/participants/#participants)

--- a/pages/about/groups/task-forces/research-questions.md
+++ b/pages/about/groups/task-forces/research-questions.md
@@ -11,7 +11,7 @@ github:
 {% include box.html type="start" title="Summary" class="" %}
 {:/}
 
-Find out about the activities of the Research Questions (RQ) Task Force and how you can contribute to its objectives.
+Find out about the activities of the Research Questions Task Force and how you can contribute to its objectives.
 
 {::nomarkdown}
 {% include box.html type="end" %}
@@ -32,29 +32,35 @@ Find out about the activities of the Research Questions (RQ) Task Force and how 
 
 ## Objectives
 
-The objectives of the RQ Task Force are to identify accessibility barriers and knowledge gaps in emerging and future web technologies; publish the research findings on those barriers and gaps; and support W3C’s horizontal reviews of web technologies as they mature and are normatively specified.
+The Research Questions Task Force:
+
+- identifies accessibility barriers and knowledge gaps in emerging and future web technologies,
+- publishes research findings to help ameliorate those barriers and gaps, and
+- supports W3C’s horizontal reviews of web technologies.
 
 ## Work statement
 
-To learn about the focus, scope and deliverables of the task force, see the [RQ Task Force Work Statement](/about/groups/task-forces/research-questions/work-statement/).
+To learn about the focus, scope and deliverables of the task force, see the [Research Questions Task Force Work Statement](/about/groups/task-forces/research-questions/work-statement/).
 
 ## Current work
 
-The RQ Task Force supports the deliverables of the [Accessible Platform Architectures (APA) Working Group](/about/groups/apawg/).
+The Research Questions Task Force supports the deliverables of the [Accessible Platform Architectures (APA) Working Group](/about/groups/apawg/).
 
-For details of the current work, see the [RQ Task Force wiki](https://www.w3.org/WAI/APA/task-forces/research-questions/wiki/Main_Page).
+For details of the current work, see the [Research Questions Task Force wiki](https://www.w3.org/WAI/APA/task-forces/research-questions/wiki/Main_Page).
 
 ## Contribute to the work
 
-The RQ Task Force welcomes input from the global accessibility community on the emerging and future web technologies research work.
+The Research Questions Task Force welcomes input from individuals and organizations around the world on the emerging and future web technologies research work.
 
 ### Contribute without joining the task force
 
-You can contribute to the work without being a member of the task force by commenting on or proposing solutions for open issues in the [Research Questions GitHub repository](https://github.com/w3c/rqtf/issues).
+You can contribute to the work without being a member of the task force by commenting on or proposing solutions for open issues.
+
+Either comment / raise a new issue in the [Research Questions GitHub repository](https://github.com/w3c/rqtf/issues) or email the [chairs](https://www.w3.org/groups/tf/rqtf/participants/#chairs).
 
 ### Become a participant in the task force
 
-Joining the RQ Task Force enables you to participate fully in the development of the work and influence the deliverables. You and your organization will also be listed as contributors, where appropriate.
+Joining the Research Questions Task Force enables you to participate fully in the development of the work and influence the deliverables. You and your organization will also be listed as contributors, where appropriate.
 
 Being a participant involves commitment to support the work of the task force in the following ways:
 
@@ -62,13 +68,13 @@ Being a participant involves commitment to support the work of the task force in
 * Keep up with weekly tasks and the progress of the work &mdash; for example, via the minutes of past meetings, mailing list discussions, and GitHub issue comments.
 * Give your input promptly, when it’s needed.
 
-To become a participant in the RQ Task Force, you must first be a member of the APA Working Group &mdash; see [Instructions for joining the Accessible Platform Architectures Working Group](https://www.w3.org/groups/wg/apa/instructions/).
+To become a participant in the Research Questions Task Force, you must first be a member of the APA Working Group &mdash; see [Instructions for joining the Accessible Platform Architectures Working Group](https://www.w3.org/groups/wg/apa/instructions/).
 
 Once you are a member of the APA Working Group, email the [W3C staff contact for the Research Questions Task Force](https://www.w3.org/groups/tf/rqtf/participants/#staff) to let them know you’d like to join the task force.
 
 **Note:** As a participant in one of the APA Working Group’s task forces, you can choose to focus your time exclusively on the task force deliverables and you do not have to contribute to the working group’s other activities.
 
-## Task force members
+## Task force participants
 
 * [Chairs](https://www.w3.org/groups/tf/rqtf/participants/#chairs)
 * [Current participants](https://www.w3.org/groups/tf/rqtf/participants/#participants)
@@ -81,8 +87,8 @@ Once you are a member of the APA Working Group, email the [W3C staff contact for
 
 ## Publications
 
-When the RQ Task Force develops publications, they will be listed here.
+When the Research Questions Task Force develops publications, they will be listed here.
 
 ## Contact the chairs
 
-If you have a question for the RQ Task Force, email the [chairs](https://www.w3.org/groups/tf/rqtf/participants/#chairs) or the [W3C staff contact](https://www.w3.org/groups/tf/rqtf/participants/#staff).
+If you have a question for the Research Questions Task Force, email the [chairs](https://www.w3.org/groups/tf/rqtf/participants/#chairs) or the [W3C staff contact](https://www.w3.org/groups/tf/rqtf/participants/#staff).

--- a/pages/about/groups/task-forces/spoken-presentation.md
+++ b/pages/about/groups/task-forces/spoken-presentation.md
@@ -51,7 +51,7 @@ For details of the current work, see:
 
 For more information on the spoken presentation work, see:
 
-* [Pronunciation overview](https://www.w3.org/WAI/pronunciation/) &mdash; an overview of W3C’s pronunciation technique
+* [Pronunciation overview](/pronunciation/) &mdash; an overview of W3C’s pronunciation technique
 * [Pronunciation video {% include_cached external.html %}](https://ln.sync.com/dl/10e1a9c60/92faztk9-he4wbve6-twt5jp3h-zuh6brfd) &mdash; a technical demonstration of approaches for controlling pronunciation in spans of web content where uniform markup can make a difference
 
 ## Contribute to the work

--- a/pages/about/groups/task-forces/spoken-presentation.md
+++ b/pages/about/groups/task-forces/spoken-presentation.md
@@ -34,16 +34,11 @@ Find out about the activities of the Spoken Presentation (previously known as Pr
 
 ## Objectives
 
-The objective of the Spoken Presentation Task Force is to develop normative specifications and best practice guidance on providing proper pronunciation for HTML content across operating systems, so that words are pronounced correctly when using text-to-speech (TTS) synthesis and users’ preferred assistive technologies.
+The Spoken Presentation Task Force develops normative specifications and best practice guidance that provides author-controlled markup to define precise pronunciation across environments when content authors need certainty, as opposed to cross-platform heuristic variability.
 
 ## Work statement
 
 To learn about the focus, scope and deliverables of the task force, see the [Spoken Presentation Task Force Work Statement](/about/groups/task-forces/spoken-presentation/work-statement/).
-
-## Overview of the spoken presentation work
-
-* [Pronunciation overview](https://www.w3.org/WAI/pronunciation/) &mdash; an overview of W3C’s pronunciation technique
-* [Pronunciation video {% include_cached external.html %}](https://ln.sync.com/dl/10e1a9c60/92faztk9-he4wbve6-twt5jp3h-zuh6brfd) &mdash; a technical demonstration of approaches for controlling pronunciation in spans of web content where uniform markup can make a difference
 
 ## Current work
 
@@ -54,15 +49,24 @@ For details of the current work, see:
 * [Spoken Presentation Task Force wiki](https://github.com/w3c/pronunciation/wiki/)
 * [Spoken Presentation Task Force current work](https://github.com/w3c/pronunciation/blob/master/README.md)
 
+For more information on the spoken presentation work, see:
+
+* [Pronunciation overview](https://www.w3.org/WAI/pronunciation/) &mdash; an overview of W3C’s pronunciation technique
+* [Pronunciation video {% include_cached external.html %}](https://ln.sync.com/dl/10e1a9c60/92faztk9-he4wbve6-twt5jp3h-zuh6brfd) &mdash; a technical demonstration of approaches for controlling pronunciation in spans of web content where uniform markup can make a difference
+
 ## Contribute to the work
 
-The Spoken Presentation Task Force welcomes input from the global accessibility community on the pronunciation work.
+The Spoken Presentation Task Force welcomes input from individuals and organizations around the world on the pronunciation work.
 
 ### Contribute without joining the task force
 
-You can contribute to the work without being a member of the task force in the [Pronunciation GitHub repository](https://github.com/w3c/pronunciation/issues):
-* If you’re aware of an issue with any of the published Spoken Presentation resources, raise a new issue.
-* Comment on or propose solutions for open pronunciation issues.
+You can contribute to the work without being a member of the task force:
+
+- **Draft Accessibility Maturity Model resources:** Review and provide feedback on drafts that are still being developed.
+- **Open Accessibility Maturity Model issues:** Comment on or propose solutions for open issues.
+- **Published Accessibility Maturity Model resources:** Let us know if there is a new issue with any of these.
+
+Either comment / raise a new issue in the [Pronunciation GitHub repository](https://github.com/w3c/pronunciation/issues) or email the [chairs](https://www.w3.org/groups/tf/pronunciation-tf/participants/#chairs).
 
 ### Become a participant in the task force
 
@@ -80,7 +84,7 @@ Once you are a member of the APA Working Group, email the [W3C staff contact for
 
 **Note:** As a participant in one of the APA Working Group’s task forces, you can choose to focus your time exclusively on the task force deliverables and you do not have to contribute to the working group’s other activities.
 
-## Task force members
+## Task force participants
 
 * [Chairs](https://www.w3.org/groups/tf/pronunciation-tf/participants/#chairs)
 * [Current participants](https://www.w3.org/groups/tf/pronunciation-tf/participants/#participants)
@@ -95,17 +99,17 @@ Once you are a member of the APA Working Group, email the [W3C staff contact for
 
 The Spoken Presentation Task Force develops and maintains the following resources for the APA Working Group:
 
-* [Pronunciation User Scenarios &mdash; 2019 Public Working Draft](https://www.w3.org/TR/pronunciation-user-scenarios/) &mdash; provides examples of:
+* [Pronunciation User Scenarios &mdash; Working Draft](https://www.w3.org/TR/pronunciation-user-scenarios/); (and latest [Editor’s Draft](https://w3c.github.io/pronunciation/user-scenarios/)) &mdash; provides examples of:
     - end-users, including screen reader users
     - content providers, including educators
     - software developers, including content managements systems
-* [Pronunciation Gap Analysis and Use &mdash; 2020 Public Working Draft](https://www.w3.org/TR/pronunciation-gap-analysis-and-use-cases/) &mdash; provides details of the gap analysis:
+* [Pronunciation Gap Analysis and Use Cases &mdash; Working Draft](https://www.w3.org/TR/pronunciation-gap-analysis-and-use-cases/) (and latest [Editor’s Draft](https://w3c.github.io/pronunciation/gap-analysis_and_use-case/)) &mdash; provides details of the gap analysis:
     - gives more contextual details
     - describes required features for pronunciation and spoken presentation
     - describes specific implementation approaches for introducing presentation authoring markup into HTML5 (called “use cases”)
     - provides a gap analysis
     - describes how the required features may be met by existing approaches    
-* [Explainer: Improving Spoken Presentation on the Web &mdash; 2020 Public Working Draft](https://www.w3.org/TR/pronunciation-explainer/): &mdash; provides an overview of the work:
+* [Explainer: Improving Spoken Presentation on the Web &mdash; Working Draft](https://www.w3.org/TR/pronunciation-explainer/) (and latest [Editor’s Draft](https://w3c.github.io/pronunciation/explainer/)) &mdash; provides an overview of the work:
     - briefly introduces the context for W3C work on pronunciation
     - describes the advantages and disadvantages of two approaches
     - poses questions for additional input

--- a/pages/about/groups/task-forces/wcag2ict.md
+++ b/pages/about/groups/task-forces/wcag2ict.md
@@ -32,12 +32,11 @@ Find out about the activities of the WCAG2ICT Task Force and how you can contrib
 
 ## Objectives
 
-The objective of the WCAG2ICT Task Force is to develop documentation describing how WCAG 2.x and its principles, guidelines, and success criteria could apply to non-Web Information and Communications Technologies (ICT).
+The WCAG2ICT Task Force develops documentation describing how WCAG 2.x and its principles, guidelines, and success criteria could apply to non-Web Information and Communications Technologies (ICT).
 
 ## Work statement
 
 To learn about the focus, scope and deliverables of the task force, see the [WCAG2ICT Task Force Work Statement](/about/groups/task-forces/wcag2ict/work-statement/).
-
 
 ## Current work
 
@@ -45,15 +44,21 @@ The WCAG2ICT Task Force supports the deliverables of the [Accessibility Guidelin
 
 For details of the current work, see the [WCAG2ICT Task Force wiki](https://github.com/w3c/wcag2ict/wiki).
 
+For more information, see [WCAG2ICT Overview](https://www.w3.org/WAI/standards-guidelines/wcag/non-web-ict/).
+
 ## Contribute to the work
 
-The WCAG2ICT Task Force welcomes input from the global accessibility community on the work to update accessibility guidelines to include non-web documents and software.
+The WCAG2ICT Task Force welcomes input from individuals and organizations around the world on the work to update accessibility guidelines to include non-web documents and software.
 
 ### Contribute without joining the task force
 
-You can contribute to the work without being a member of the task force in the [WCAG2ICT GitHub repository](https://github.com/w3c/wcag2ict/issues):
-* If you’re aware of an issue with any of the published WCAG2ICT resources, raise a new issue.
-* Comment on or propose solutions for open WCAG2ICT issues.
+You can contribute to the work without being a member of the task force:
+
+- **Draft WCAG2ICT resources:** Review and provide feedback on drafts that are still being developed.
+- **Open WCAG2ICT issues:** Comment on or propose solutions for open issues.
+- **Published WCAG2ICT resources:** Let us know if there is a new issue with any of these.
+
+Either comment / raise a new issue in the [WCAG2ICT GitHub repository](https://github.com/w3c/wcag2ict/issues) or email the [chairs](https://www.w3.org/groups/tf/wcag2ict/participants/#chairs).
 
 ### Become a participant in the task force
 
@@ -71,7 +76,7 @@ Once you are a member of the AG Working Group, email the [W3C Staff Contact for 
 
 **Note:** As a participant in one of the AG Working Group’s task forces, you can choose to focus your time exclusively on the task force deliverables and you do not have to contribute to the working group’s other activities.
 
-## Task force members
+## Task force participants
 
 * [Chairs](https://www.w3.org/groups/tf/wcag2ict/participants/#chairs)
 * [Current participants](https://www.w3.org/groups/tf/wcag2ict/participants/#participants)
@@ -84,11 +89,7 @@ Once you are a member of the AG Working Group, email the [W3C Staff Contact for 
 
 ## Publications
 
-The WCAG2ICT Task Force develops and maintains the following resources for the AG Working Group:
-
-* [Guidance on Applying WCAG 2.0 to Non-Web Information and Communications Technologies &mdash; 2013 Working Group Note](https://www.w3.org/TR/wcag2ict-20/) &mdash; provides guidance on WCAG 2.0 success criteria
-* [Guidance on Applying WCAG 2 to Non-Web Information and Communications Technologies &mdash; 2024 Group Note](https://www.w3.org/TR/wcag2ict/) &mdash; provides guidance on 2.0, 2.1, and 2.2 success criteria, and supersedes the previous Note
-* [Guidance on Applying WCAG 2 to Non-Web Information and Communications Technologies (WCAG2ICT) &mdash; 2024 Editor’s Draft](https://www.w3.org/TR/maturity-model/) &mdash; provides informative (non-normative) guidance on how WCAG 2.x can be applied to non-web documents and software
+The WCAG2ICT Task Force develops and maintains the following resource for the AG Working Group: [Guidance on Applying WCAG 2 to Non-Web Information and Communications Technologies (WCAG2ICT) &mdash; Group Note](https://www.w3.org/TR/wcag2ict/) (and latest [Editor’s Draft](https://w3c.github.io/wcag2ict/)) &mdash; this provides informative (non-normative) guidance on 2.0, 2.1, and 2.2 success criteria and how WCAG 2.x can be applied to non-web documents and software.
 
 ## Contact the chairs
 

--- a/pages/about/groups/task-forces/wcag2ict.md
+++ b/pages/about/groups/task-forces/wcag2ict.md
@@ -44,7 +44,7 @@ The WCAG2ICT Task Force supports the deliverables of the [Accessibility Guidelin
 
 For details of the current work, see the [WCAG2ICT Task Force wiki](https://github.com/w3c/wcag2ict/wiki).
 
-For more information, see [WCAG2ICT Overview](https://www.w3.org/WAI/standards-guidelines/wcag/non-web-ict/).
+For more information, see [WCAG2ICT Overview](/standards-guidelines/wcag/non-web-ict/).
 
 ## Contribute to the work
 

--- a/pages/about/groups/task-forces/wcag2x-backlog.md
+++ b/pages/about/groups/task-forces/wcag2x-backlog.md
@@ -32,12 +32,14 @@ Find out about the activities of the WCAG 2.x Backlog Task Force and how you can
 
 ## Objectives
 
-The objectives of the WCAG 2.x Backlog Task Force are to maintain up-to-date versions of the normative and informative materials associated with versions 2.0, 2.1, and 2.2 (2.x) of the Web Content Accessibility Guidelines (WCAG); and to document considerations for WCAG 3.0 that cannot be readily addressed within the existing normative language of the WCAG 2.x specification.
+The WCAG 2.x Backlog Task Force:
+
+- maintains up-to-date versions of the normative and informative materials associated with versions 2.0, 2.1, and 2.2 (2.x) of the Web Content Accessibility Guidelines (WCAG), and
+- documents considerations for WCAG 3.0 that cannot be readily addressed within the existing normative language of the WCAG 2.x specification.
 
 ## Work statement
 
 To learn about the focus, scope and deliverables of the task force, see the [WCAG 2.x Backlog Task Force Work Statement](/about/groups/task-forces/wcag2x-backlog/work-statement/).
-
 
 ## Current work
 
@@ -54,11 +56,16 @@ The process includes a two-week review of all changes by the AG Working Group.
 
 ## Contribute to the work
 
-The WCAG 2.x Backlog Task Force welcomes input from the global accessibility community on the work to resolve WCAG 2.x issues.
+The WCAG 2.x Backlog Task Force welcomes input from individuals and organizations around the world on the work to resolve WCAG 2.x issues.
 
 ### Contribute without joining the task force
 
-You can contribute to the work without being a member of the task force by commenting on or proposing solutions for open issues in the [WCAG GitHub repository](https://github.com/w3c/wcag/issues).
+You can contribute to the work without being a member of the task force:
+
+* If you’re aware of an issue with any of the published WCAG 2.x resources, raise a new issue.
+* Comment on or propose solutions for open WCAG 2.x issues.
+
+Either comment / raise a new issue in the [WCAG GitHub repository](https://github.com/w3c/wcag/issues) or email the [chairs](https://www.w3.org/groups/tf/wcag2x-backlog/participants/#chairs).
 
 ### Become a participant in the task force
 
@@ -76,7 +83,7 @@ Once you are a member of the AG Working Group, email the [W3C staff contact for 
 
 **Note:** As a participant in one of the AG Working Group’s task forces, you can choose to focus your time exclusively on the task force deliverables and you do not have to contribute to the working group’s other activities.
 
-## Task force members
+## Task force participants
 
 * [Chairs](https://www.w3.org/groups/tf/wcag2x-backlog/participants/#chairs)
 * [Participants](https://www.w3.org/groups/tf/wcag2x-backlog/participants/)


### PR DESCRIPTION
This PR re-introduces most changes from https://github.com/w3c/wai-website/pull/1107, that had been reverted by https://github.com/w3c/wai-website/pull/1360.

It does not includes changes to the following pages, that will be added through a separate PR:
- /news/subscribe/
- /about/
- /about/contacting/
- /about/translating/
- /about/using-wai-material/

@netlify /