### PR TITLE
Set correct branch for statements pages for Fork & Edit button

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -301,6 +301,13 @@ defaults:
         alt: Accessibility Roles and Responsibilities Mapping (ARRM). W3C Web Accessibility Initiative (WAI). icons of hand, eye, brain, ear, speech, body.
   -
     scope:
+      path: "pages/planning-policies/statements"
+    values:
+      github:
+        repository: w3c/wai-statements
+        branch: master
+  -
+    scope:
       path: "_translations-sitemaps"
     values:
       lang: en


### PR DESCRIPTION
Fixes https://github.com/w3c/wai-statements/issues/200.

This sets `github.branch` to `master` for pages under `/planning/statements/`, so that the Fork & Edit links on those pages will work properly in the context of the full wai-website repo.

Those links already work properly in isolation within the wai-statements repository, because the [theme include](https://github.com/w3c/wai-website-theme/blob/main/_includes/github-file-path.html) responsible for resolving this data falls back to `master` if it is never defined.

@netlify /planning/statements/