### PR TITLE
Add explicit trailing slash to meeting minutes URL to avoid redirect

### DIFF
--- a/_plugins/minutes-plugin.rb
+++ b/_plugins/minutes-plugin.rb
@@ -11,7 +11,7 @@ module Jekyll
       site.data['minutes']['groups'].each {|id, channels| requested_channels.push(*channels)}
 
       minutesUri =
-        URI("https://www.w3.org/services/meeting-minutes?format=json&num=#{limit}&channels=#{requested_channels.uniq().join(',')}")
+        URI("https://www.w3.org/services/meeting-minutes/?format=json&num=#{limit}&channels=#{requested_channels.uniq().join(',')}")
 
       rawData = nil
       begin


### PR DESCRIPTION
Gerald and Vivien recently did more work on rewrite rules for the meeting-minutes service, to facilitate prettier URLs for meeting minutes. In the process, they added a redirect from meeting-minutes with no trailing slash, to with a trailing slash. This seems to be enough to confuse this repo's plugin; explicitly adding the trailing slash is enough to resolve it.

@netlify /about/groups/agwg/minutes/