### PR TITLE
Use pretty format for minutes URL

### DIFF
--- a/_plugins/minutes-plugin.rb
+++ b/_plugins/minutes-plugin.rb
@@ -11,7 +11,7 @@ module Jekyll
       site.data['minutes']['groups'].each {|id, channels| requested_channels.push(*channels)}
 
       minutesUri =
-        URI("https://www.w3.org/services/meeting-minutes/?format=json&num=#{limit}&channels=#{requested_channels.uniq().join(',')}")
+        URI("https://www.w3.org/services/meeting-minutes/#{requested_channels.uniq().join(',')}/?format=json&num=#{limit}")
 
       rawData = nil
       begin


### PR DESCRIPTION
Suggested by Vivien in https://github.com/w3c/wai-website/pull/1481#discussion_r2306552759

Tested locally to verify the plugin still runs successfully. Also verified that both URLs function the same with a reduced test case.

@netlify /about/groups/agwg/minutes/