### PR TITLE
Update services-link include to use pretty URLs

### DIFF
--- a/_includes/minutes/services-link.liquid
+++ b/_includes/minutes/services-link.liquid
@@ -4,4 +4,4 @@ Renders link to meeting minutes topic scraper.
 Expected input:
 - group - name of group, matching a key in _data/minutes/groups.json
 {% endcomment -%}
-<a href="https://www.w3.org/services/meeting-minutes?num=200&channels={{ site.data.minutes.groups[include.group] | join: ',' }}">meeting minutes</a>
+<a href="https://www.w3.org/services/meeting-minutes/{{ site.data.minutes.groups[include.group] | join: ',' }}/?num=200">meeting minutes</a>


### PR DESCRIPTION
This updates links pointing to minutes scraper service pages, which @vivienlacourba pointed out I missed in https://github.com/w3c/wai-website/pull/1483#issuecomment-3237637350

@netlify /about/groups/agwg/minutes/