### PR TITLE
research/user-requirements: Fix last_updated

### DIFF
--- a/pages/fundamentals/research/user-requirements.md
+++ b/pages/fundamentals/research/user-requirements.md
@@ -2,7 +2,7 @@
 title: "Digital Accessibility User Requirements"
 nav_title: "User Requirements"
 lang: en
-last_updated: 2026-03-05
+last_updated: 2025-03-05
 description: User requirements for virtual or immersive environments (XR), real-time communication (RTC), natural language interfaces, multimedia, cognitive accessibility, low vision, and more.
 
 github:


### PR DESCRIPTION
I noticed the `last_updated` timestamp for this page is in the future. Its last commit was https://github.com/w3c/wai-website/commit/c0b84736, so it was off by one year.

@netlify /research/user-requirements/