### PR TITLE
Display comments about WCAG 2 translations

### DIFF
--- a/pages/standards-guidelines/wcag/translations.md
+++ b/pages/standards-guidelines/wcag/translations.md
@@ -167,6 +167,7 @@ Two types of translations are listed on this page:
               <span class="translation-level">Planned Authorized Translation</span>
               {% if trans.intent_email %}<p><a href="{{ trans.intent_email }}">Notification of intent ({{ trans.intent_date | date: "%-d %B %Y"}})</a></p>{% endif %}
           {% endcase %}
+          {% if trans.comment %}<p>{{ trans.comment }}</p>{% endif %}
           </div>
         {%- endfor -%}
       </td>
@@ -174,7 +175,6 @@ Two types of translations are listed on this page:
   {%- endfor -%}
   </tbody>
 </table>
-
 
 ## WCAG 2.0
 
@@ -212,6 +212,7 @@ Two types of translations are listed on this page:
               <span class="translation-level">Planned Authorized Translation</span>
               {% if trans.intent_email %}<p><a href="{{ trans.intent_email }}">Notification of intent ({{ trans.intent_date | date: "%-d %B %Y"}})</a></p>{% endif %}
           {% endcase %}
+          {% if trans.comment %}<p>{{ trans.comment }}</p>{% endif %}
           </div>
         {%- endfor -%}
       </td>


### PR DESCRIPTION
This PR allows to display a comment about a translation of WCAG 2. For example, this is helpful to indicate that W3C has received an intent to update an authorized translation.

To display a comment about a translation, use the `comment` key in [`standards-translations.yml`](https://github.com/w3c/wai-website-data/blob/master/standards-translations.yml) (in the `wai-website-data` repository). For example, see https://github.com/w3c/wai-website-data/pull/211

<!--If your PR has a primary page for review, set an entry path.
    Add a relative path next to `@netlify` below.-->

@netlify /standards-guidelines/wcag/translations/