### PR TITLE
Update ACT Rules Format 1.1 status

### DIFF
--- a/pages/about/groups/task-forces/conformance-testing.md
+++ b/pages/about/groups/task-forces/conformance-testing.md
@@ -91,7 +91,7 @@ Once you are a member of the AG Working Group, email the [W3C Staff Contact for 
 
 The ACT Task Force develops and maintains the following resources for the AG Working Group:
 
-* [Accessibility Conformance Testing (ACT) Rules Format 1.1 — W3C Candidate Recommendation Snapshot](https://www.w3.org/TR/act-rules-format-1.1/) (and latest [Editor’s Draft](https://w3c.github.io/wcag-act/act-rules-format.html))
+* [Accessibility Conformance Testing (ACT) Rules Format 1.1 — W3C Recommendation](https://www.w3.org/TR/act-rules-format-1.1/) (and latest [Editor’s Draft](https://w3c.github.io/wcag-act/act-rules-format.html))
 * [Repository of published Accessibility Conformance Testing (ACT) Rules](https://www.w3.org/WAI/standards-guidelines/act/rules/)
 
 ## Contact the task force


### PR DESCRIPTION
After today's publication of [ACT Rules Format 1.1](https://www.w3.org/TR/act-rules-format/)

@netlify /about/groups/task-forces/conformance-testing/