### PR TITLE
Translate WCAG 2 Overview to Swahili

### DIFF
--- a/pages/standards-guidelines/wcag/index.md
+++ b/pages/standards-guidelines/wcag/index.md
@@ -2,26 +2,23 @@
 # Translation instructions are after the "#" character in this first section. They are comments that do not show up in the web page. You do not need to translate the instructions after "#".
 # In this first section, do not translate the words before a colon. For example, do not translate "title:". Do translate the text after "title:".
 
-title: "WCAG 2 Overview"
-nav_title: "Web Content – WCAG 2"
-lang: en  # Change "en" to the translated-language shortcode
-last_updated: 2025-10-20 # Keep the date of the English version
+title: "Muhtasari wa WCAG 2"
+nav_title: "Maudhui ya Wavuti – WCAG 2"
+lang: sw  
+last_updated: 2025-10-20 
 first_published: "July 2005"
-description: Introduces the Web Content Accessibility Guidelines (WCAG) international standard, including WCAG 2.0, WCAG 2.1, and WCAG 2.2. WCAG documents explain how to make web content more accessible to people with disabilities.
+description: Inatambulisha kiwango cha kimataifa cha Miongozo ya Ufikiaji wa Maudhui ya Wavuti (WCAG), ikijumuisha WCAG 2.0, WCAG 2.1, na WCAG 2.2. Nyaraka za WCAG zinaeleza jinsi ya kufanya maudhui ya wavuti yafikiwe zaidi na watu wenye ulemavu.
 
-# translators: # remove from the beginning of this line and the lines below: "# " (the hash sign and the space)
-# - name: "Translator Name Here" # Add one -name: line for every translator
-# - name: "Jan Doe"   # Replace Jan Doe with translator name
-# - name: "Jan Doe"   # Replace Jan Doe with name, or delete this line if not multiple translators
+translators: 
+- name: Ben Luke Psaila 
 # contributors:
-# - name: "Jan Doe"   # Replace Jan Doe with contributor name, or delete this line if none
-# - name: "Jan Doe"   # Replace Jan Doe with name, or delete this line if not multiple contributors
+# - name: Ben Luke Psaila  
 
 github:
   label: wai-wcag-intro
 
-permalink: /standards-guidelines/wcag/  # Add the language shortcode to the end, with no slash at end, for example: /link/to/page/fr
-ref: /standards-guidelines/wcag/  # Do not change this
+permalink: /standards-guidelines/wcag/sw  
+ref: /standards-guidelines/wcag/  
 
 image: /content-images/wcag/general-social.png
 feedbackmail: wai@w3.org
@@ -31,31 +28,31 @@ feedbackmail: wai@w3.org
 # Translate the other words below, including "Date:" and "Editor:"
 # Translate the Working Group name. Leave the Working Group acronym in English.
 footer: >
-  <p><strong>Editor:</strong> <a href="https://www.w3.org/People/Shawn/">Shawn Lawton Henry</a>.</p>
-  <p>Developed with input from the Education and Outreach Working Group (<a href="https://www.w3.org/WAI/about/groups/eowg/">EOWG</a>) and the Accessibility Guidelines Working Group (<a href="https://www.w3.org/WAI/about/groups/agwg/">AG WG</a>).</p>
+  <p><strong>Mhariri:</strong> <a href="https://www.w3.org/People/Shawn/">Shawn Lawton Henry</a>.</p>
+  <p>Imetengenezwa kwa mchango kutoka kwa Education and Outreach Working Group (<a href="https://www.w3.org/WAI/about/groups/eowg/">EOWG</a>) na Accessibility Guidelines Working Group (<a href="https://www.w3.org/WAI/about/groups/agwg/">AG WG</a>).</p>
 ---
 
 {::nomarkdown}
-{% include box.html type="start" h="2" title="Summary" class="full" %}
+{% include box.html type="start" h="2" title="Muhtasari" class="full" %}
 {:/}
 
-This page introduces the Web Content Accessibility Guidelines (WCAG) international standard, including WCAG 2.0, WCAG 2.1, and WCAG 2.2. WCAG documents explain how to make web content more accessible to people with disabilities.
+Ukurasa huu unatambulisha kiwango cha kimataifa cha Miongozo ya Ufikiaji wa Maudhui ya Wavuti (WCAG), ikijumuisha WCAG 2.0, WCAG 2.1, na WCAG 2.2. Nyaraka za WCAG zinaeleza jinsi ya kufanya maudhui ya wavuti yafikiwe zaidi na watu wenye ulemavu.
 
-A different page [introduces WCAG 3](/standards-guidelines/wcag/wcag3-intro/).
+Ukurasa tofauti [unatambulisha WCAG 3](/standards-guidelines/wcag/wcag3-intro/).
 
-WCAG is not an introduction to accessibility. For introductions, see [Accessibility Fundamentals Overview](/fundamentals/).
+WCAG si utangulizi wa ufikiaji. Kwa utangulizi, tazama [Muhtasari wa Misingi ya Ufikiaji](/fundamentals/).
 
-Quick links to resources:
-* [How to Meet WCAG 2 (Quick Reference)](https://www.w3.org/WAI/WCAG22/quickref/)
-* [WCAG 2.2 Standard](https://www.w3.org/TR/WCAG22/), [What's New in WCAG 2.2](/standards-guidelines/wcag/new-in-22/)
-* [WCAG 2.1 Standard](https://www.w3.org/TR/WCAG21/)
+Viungo vya haraka vya rasilimali:
+* [Jinsi ya Kukidhi WCAG 2 (Rejea ya Haraka)](https://www.w3.org/WAI/WCAG22/quickref/)
+* [Kiwango cha WCAG 2.2](https://www.w3.org/TR/WCAG22/), [Nini Kipya katika WCAG 2.2](/standards-guidelines/wcag/new-in-22/)
+* [Kiwango cha WCAG 2.1](https://www.w3.org/TR/WCAG21/)
 
 {::nomarkdown}
 {% include box.html type="end" %}
 {:/}
 
 {::nomarkdown}
-{% include_cached toc.html type="start" title="Page Contents" class="simple" %}
+{% include_cached toc.html type="start" title="Yaliyomo Ukurasani" class="simple" %}
 {:/}
 
 {::options toc_levels="2" /}
@@ -66,108 +63,108 @@ Quick links to resources:
 {% include_cached toc.html type="end" %}
 {:/}
 
-## Introduction {#intro}
+## Utangulizi {#intro}
 
-Web Content Accessibility Guidelines (WCAG) 2 is developed through the [W3C process](/standards-guidelines/w3c-process/) in cooperation with individuals and organizations around the world, with a goal of providing a single shared standard for web content accessibility that meets the needs of individuals, organizations, and governments internationally.
+Miongozo ya Ufikiaji wa Maudhui ya Wavuti (WCAG) 2 inatengenezwa kupitia [mchakato wa W3C](/standards-guidelines/w3c-process/) kwa ushirikiano na watu na mashirika duniani kote, kwa lengo la kutoa kiwango kimoja cha pamoja cha ufikiaji wa maudhui ya wavuti kinachokidhi mahitaji ya watu, mashirika, na serikali kimataifa.
 
-The WCAG documents explain how to make web content more accessible to people with disabilities. Web "content" generally refers to the information in a web page or web application, including:
+Nyaraka za WCAG zinaeleza jinsi ya kufanya maudhui ya wavuti yafikiwe zaidi na watu wenye ulemavu. "Maudhui" ya wavuti kwa ujumla inarejelea taarifa katika ukurasa wa wavuti au programu ya wavuti, ikijumuisha:
 
--   natural information such as text, images, and sounds
--   code or markup that defines structure, presentation, etc.
+-   taarifa asilia kama vile maandishi, picha, na sauti
+-   kodi au alama zinazofafanua muundo, uwasilishaji, n.k.
 
-## Who WCAG is for {#for}
+## WCAG ni kwa ajili ya nani {#for}
 
-WCAG is for those who want a technical standard. **It is not an introduction to accessibility. For links to introductory material, see [“Where should I start?” in the FAQ](/standards-guidelines/wcag/faq/#start).**
+WCAG ni kwa wale wanaohitaji kiwango cha kiufundi. **Si utangulizi wa ufikiaji. Kwa viungo vya nyenzo za utangulizi, tazama [“Nianzie wapi?” katika Maswali Yanayoulizwa Mara kwa Mara](/standards-guidelines/wcag/faq/#start).**
 
-WCAG is primarily intended for:
+WCAG kimsingi inakusudiwa kwa:
 
--   Web content developers (page authors, site designers, etc.)
--   Web authoring tool developers
--   Web accessibility evaluation tool developers
--   Others who want or need a standard for web accessibility, including for mobile accessibility
+-   Watengenezaji wa maudhui ya wavuti (waandishi wa kurasa, wabunifu wa tovuti, n.k.)
+-   Watengenezaji wa zana za uandishi wa wavuti
+-   Watengenezaji wa zana za kutathmini ufikiaji wa wavuti
+-   Wengine wanaotaka au kuhitaji kiwango cha ufikiaji wa wavuti, ikijumuisha ufikiaji wa simu za mkononi
 
-To meet the needs of others &mdash; including policy makers, managers, and researchers &mdash; there are many different [[WAI Resources]](/resources/).
+Ili kukidhi mahitaji ya wengine &mdash; ikijumuisha watunga sera, mameneja, na watafiti &mdash; kuna [[Rasilimali za WAI]](/resources/) nyingi tofauti.
 
-## What is in WCAG 2 {#whatis2}
+## Nini kimo ndani ya WCAG 2 {#whatis2}
 
-The WCAG 2.2 has 13 guidelines. The guidelines are organized under [4 principles: perceivable, operable, understandable, and robust](https://www.w3.org/WAI/WCAG22/Understanding/intro#understanding-the-four-principles-of-accessibility).
+WCAG 2.2 ina miongozo 13. Miongozo imepangwa chini ya [kanuni 4: inayoweza kutambulika, inayoweza kutumika, inayoeleweka, na imara](https://www.w3.org/WAI/WCAG22/Understanding/intro#understanding-the-four-principles-of-accessibility).
 
-For each guideline, there are testable *success criteria*. The success criteria are at [three levels: A, AA, and AAA](https://www.w3.org/WAI/WCAG22/Understanding/conformance#levels).
+Kwa kila mwongozo, kuna *vigezo vya mafanikio* vinavyoweza kupimwa. Vigezo vya mafanikio viko katika [viwango vitatu: A, AA, na AAA](https://www.w3.org/WAI/WCAG22/Understanding/conformance#levels).
 
-The success criteria are what determine "conformance" to WCAG. That is, in order to meet WCAG, the content needs to meet the success criteria. Details are in the [Conformance section of WCAG](https://www.w3.org/TR/WCAG22/#conformance).
+Vigezo vya mafanikio ndivyo vinavyoamua "ukubalifu" kwa WCAG. Yaani, ili kukidhi WCAG, maudhui yanahitaji kukidhi vigezo vya mafanikio. Maelezo yapo katika [Sehemu ya Ukubalifu ya WCAG](https://www.w3.org/TR/WCAG22/#conformance).
 
-For a short summary of the WCAG 2 guidelines, see **[[WCAG 2 at a Glance]](/standards-guidelines/wcag/glance/)**.
+Kwa muhtasari mfupi wa miongozo ya WCAG 2, tazama **[[WCAG 2 kwa Muhtasari]](/standards-guidelines/wcag/glance/)**.
 
-### Supporting material and supplemental guidance {#supplement}
+### Nyenzo za kusaidia na mwongozo wa ziada {#supplement}
 
-The following resources help you understand and implement WCAG, and improve accessibility beyond WCAG:
-* Quick Reference / How to Meet WCAG 2 / Checklist
-* Understanding WCAG 2
-* Techniques for WCAG 2
-* Test Rules for WCAG 2
-* Supplemental Guidance
+Rasilimali zifuatazo zinakusaidia kuelewa na kutekeleza WCAG, na kuboresha ufikiaji zaidi ya WCAG:
+* Rejea ya Haraka / Jinsi ya Kukidhi WCAG 2 / Orodha ya Kukagua
+* Kuelewa WCAG 2
+* Mbinu za WCAG 2
+* Sheria za Majaribio za WCAG 2
+* Mwongozo wa Ziada
 
-**Please read about these WCAG 2 resources from [WCAG 2 Documents](/standards-guidelines/wcag/docs/).**
+**Tafadhali soma kuhusu hizi rasilimali za WCAG 2 kutoka [Nyaraka za WCAG 2](/standards-guidelines/wcag/docs/).**
 
 ## WCAG 2.0, 2.1, 2.2 {#versions}
 
-The Web Content Accessibility Guidelines (WCAG) standards are referenceable when they are published as a 'W3C Recommendation' web standard.
+Viwango vya Miongozo ya Ufikiaji wa Maudhui ya Wavuti (WCAG) vinaweza kurejelewa vinapochapishwa kama kiwango cha wavuti cha 'Pendekezo la W3C'.
 
-* [WCAG 2.0](https://www.w3.org/TR/WCAG20/) was published on 11 December 2008.
-* [WCAG 2.1](https://www.w3.org/TR/WCAG21/) was published on 5 June 2018, and updates were published on 21 September 2023, 12 December 2024, and 6 May 2025.
-* [WCAG 2.2](https://www.w3.org/TR/WCAG22/) was published on 5 October 2023, and an update was published on 12 December 2024.
+* [WCAG 2.0](https://www.w3.org/TR/WCAG20/) ilichapishwa tarehe 11 Desemba 2008.
+* [WCAG 2.1](https://www.w3.org/TR/WCAG21/) ilichapishwa tarehe 5 Juni 2018, na sasisho zilichapishwa tarehe 21 Septemba 2023, 12 Desemba 2024, na 6 Mei 2025.
+* [WCAG 2.2](https://www.w3.org/TR/WCAG22/) ilichapishwa tarehe 5 Oktoba 2023, na sasisho lilichapishwa tarehe 12 Desemba 2024.
 
-For information on the updates, see the [WCAG 2 FAQ](/standards-guidelines/wcag/faq/).
+Kwa maelezo kuhusu sasisho, tazama [Maswali Yanayoulizwa Mara kwa Mara ya WCAG 2](/standards-guidelines/wcag/faq/).
 
-WCAG 2.0, 2.1, and 2.2 are designed to be "backwards compatible", which means content that conforms to WCAG 2.2 also conforms to WCAG 2.1 and WCAG 2.0. If you want to meet all the versions, you can use the WCAG 2.2 resources and you don’t need to bother looking at earlier versions.
+WCAG 2.0, 2.1, na 2.2 zimeundwa "kuendana na matoleo ya nyuma", ikimaanisha maudhui yanayokidhi WCAG 2.2 pia yanakidhi WCAG 2.1 na WCAG 2.0. Ikiwa unataka kukidhi matoleo yote, unaweza kutumia rasilimali za WCAG 2.2 na huhitaji kusumbuka kuangalia matoleo ya awali.
 
-All the success criteria from 2.0 are included in 2.1, and all from 2.1 are in 2.2 (except 4.1.1, explained in the next paragraph).
-* WCAG 2.0 has 12 guidelines.
-* WCAG 2.1 adds 1 guideline and 17 success criteria. They are introduced in [What's New in WCAG 2.1](/standards-guidelines/wcag/new-in-21/).
-* WCAG 2.2 adds 9 success criteria. They are introduced in [What's New in WCAG 2.2](/standards-guidelines/wcag/new-in-22/).
+Vigezo vyote vya mafanikio kutoka 2.0 vimejumuishwa katika 2.1, na vyote kutoka 2.1 vipo katika 2.2 (isipokuwa 4.1.1, iliyoelezwa katika aya inayofuata).
+* WCAG 2.0 ina miongozo 12.
+* WCAG 2.1 inaongeza mwongozo 1 na vigezo 17 vya mafanikio. Vinatambulishwa katika [Nini Kipya katika WCAG 2.1](/standards-guidelines/wcag/new-in-21/).
+* WCAG 2.2 inaongeza vigezo 9 vya mafanikio. Vinatambulishwa katika [Nini Kipya katika WCAG 2.2](/standards-guidelines/wcag/new-in-22/).
 
-A few things have changed, and we intend the updates in the related documents to support backwards compatibility in practice. The main change is that in WCAG 2.2, one success criteria (4.1.1 Parsing) is obsolete. Notes added to WCAG 2.1 and WCAG 2.0 errata address this, as explained in [WCAG 2 FAQ, 4.1.1 Parsing](/standards-guidelines/wcag/faq/#parsing411). WCAG 2.2 also includes Notes about different languages; more information is in [WCAG 2 FAQ, internationalization](/standards-guidelines/wcag/faq/#i18n22).
+Vitu vichache vimebadilika, na tunakusudia sasisho katika nyaraka husika kuunga mkono kuendana na matoleo ya nyuma katika vitendo. Mabadiliko makuu ni kwamba katika WCAG 2.2, kigezo kimoja cha mafanikio (4.1.1 Uchanganuzi) kimepitwa na wakati. Maelezo yaliyoongezwa kwenye WCAG 2.1 na WCAG 2.0 errata yanashughulikia hili, kama ilivyoelezwa katika [Maswali Yanayoulizwa Mara kwa Mara ya WCAG 2, 4.1.1 Uchanganuzi](/standards-guidelines/wcag/faq/#parsing411). WCAG 2.2 pia inajumuisha Maelezo kuhusu lugha tofauti; maelezo zaidi yapo katika [Maswali Yanayoulizwa Mara kwa Mara ya WCAG 2, utandawazi](/standards-guidelines/wcag/faq/#i18n22).
 
-WCAG 2.0, WCAG 2.1, and WCAG 2.2 are all existing standards. WCAG 2.2 does not deprecate or supersede WCAG 2.1, and WCAG 2.1 does not deprecate or supersede WCAG 2.0. W3C encourages you to use the latest version of WCAG.
+WCAG 2.0, WCAG 2.1, na WCAG 2.2 zote ni viwango vilivyopo. WCAG 2.2 haidharau wala kuchukua nafasi ya WCAG 2.1, na WCAG 2.1 haidharau wala kuchukua nafasi ya WCAG 2.0. W3C inakuhimiza kutumia toleo la hivi karibuni la WCAG.
 
-## Translations
+## Tafsiri
 
-Authorized Translations and unofficial translations of WCAG 2 are listed in [[WCAG 2 Translations]](/standards-guidelines/wcag/translations/).
+Tafsiri Zilizoidhinishwa na tafsiri zisizo rasmi za WCAG 2 zimeorodheshwa katika [[Tafsiri za WCAG 2]](/standards-guidelines/wcag/translations/).
 
 ## ISO/IEC 40500, EAA, EN 301 549 {#iso}
 
-WCAG 2.2 is an approved International Organization for Standardization (ISO) standard: [ISO/IEC 40500:2025](https://www.iso.org/standard/91029.html), and is available free from ISO. ISO/IEC 40500:2025 is exactly the same as the October 2023 version of WCAG 2.2. We expect the December 2024 version of WCAG 2.2 to be available as ISO/IEC 40500:2026 by late 2026.
+WCAG 2.2 ni kiwango kilichoidhinishwa cha Shirika la Kimataifa la Usanifu (ISO): [ISO/IEC 40500:2025](https://www.iso.org/standard/91029.html), na kinapatikana bure kutoka ISO. ISO/IEC 40500:2025 ni sawa kabisa na toleo la Oktoba 2023 la WCAG 2.2. Tunatarajia toleo la Desemba 2024 la WCAG 2.2 kupatikana kama ISO/IEC 40500:2026 ifikapo mwishoni mwa 2026.
 
-In addressing the European Accessibility Act (EAA), most organizations use WCAG and the European Standard EN 301 549: Accessibility requirements for ICT products and services. EN 301 549 currently uses WCAG 2.1. We expect the next version of EN 301 549 to use the latest version of WCAG 2.2.
+Katika kushughulikia Sheria ya Ufikiaji ya Ulaya (EAA), mashirika mengi hutumia WCAG na Kiwango cha Ulaya EN 301 549: Mahitaji ya ufikiaji kwa bidhaa na huduma za ICT. EN 301 549 kwa sasa inatumia WCAG 2.1. Tunatarajia toleo lijalo la EN 301 549 kutumia toleo la hivi karibuni la WCAG 2.2.
 
-To find how laws around the world use WCAG, see [Web Accessibility Laws & Policies](/policies/).
+Kujua jinsi sheria duniani kote zinavyotumia WCAG, tazama [Sheria na Sera za Ufikiaji wa Wavuti](/policies/).
 
-W3C encourages you to use the latest version of WCAG. Content that meets WCAG 2.2 also meets WCAG 2.1 and WCAG 2.0.
+W3C inakuhimiza kutumia toleo la hivi karibuni la WCAG. Maudhui yanayokidhi WCAG 2.2 pia yanakidhi WCAG 2.1 na WCAG 2.0.
 
-## Who develops WCAG {#wg}
+## Nani anatengeneza WCAG {#wg}
 
-The WCAG technical documents are developed by the Accessibility Guidelines Working Group ([AG WG](/GL/)) *(formerly the Web Content Accessibility Guidelines Working Group)*, which is part of the World Wide Web Consortium ([W3C](https://www.w3.org)) Web Accessibility Initiative ([WAI](https://www.w3.org/WAI/)).
+Nyaraka za kiufundi za WCAG zinatengenezwa na Accessibility Guidelines Working Group ([AG WG](/GL/)) *(zamani Web Content Accessibility Guidelines Working Group)*, ambayo ni sehemu ya World Wide Web Consortium ([W3C](https://www.w3.org)) Web Accessibility Initiative ([WAI](https://www.w3.org/WAI/)).
 
-WAI updates Techniques for WCAG 2 and Understanding WCAG 2 periodically. We welcome [comments](/standards-guidelines/wcag/commenting/) and [submission of new techniques](https://www.w3.org/WAI/GL/WCAG20/TECHS-SUBMIT/).
+WAI husasisha Mbinu za WCAG 2 na Kuelewa WCAG 2 mara kwa mara. Tunakaribisha [maoni](/standards-guidelines/wcag/commenting/) na [uwasilishaji wa mbinu mpya](https://www.w3.org/WAI/GL/WCAG20/TECHS-SUBMIT/).
 
-Opportunities for contributing to WCAG and other WAI work are introduced in [[Participating in WAI]](/about/participating/).
+Fursa za kuchangia kwa WCAG na kazi zingine za WAI zinatambulishwa katika [[Kushiriki katika WAI]](/about/participating/).
 
-## More about WCAG {#more}
+## Zaidi kuhusu WCAG {#more}
 
-WCAG is part of a series of accessibility guidelines, including the Authoring Tool Accessibility Guidelines (ATAG) and the User Agent Accessibility Guidelines (UAAG). [[Essential Components of Web Accessibility]](/fundamentals/components/) explains the relationship between the different guidelines.
+WCAG ni sehemu ya mfululizo wa miongozo ya ufikiaji, ikijumuisha Authoring Tool Accessibility Guidelines (ATAG) na User Agent Accessibility Guidelines (UAAG). [[Vipengele Muhimu vya Ufikiaji wa Wavuti]](/fundamentals/components/) inaeleza uhusiano kati ya miongozo tofauti.
 
-### Frequently asked questions (FAQ) {#faq}
+### Maswali yanayoulizwa mara kwa mara (FAQ) {#faq}
 
-See the [[WCAG 2 FAQ]](/standards-guidelines/wcag/faq/) for more information on:
+Tazama [[Maswali Yanayoulizwa Mara kwa Mara ya WCAG 2]](/standards-guidelines/wcag/faq/) kwa maelezo zaidi kuhusu:
 
--   **WCAG 2 coverage of [mobile accessibility](/standards-guidelines/wcag/faq/#mobile)**
--   **Applying WCAG 2 to [documents and software](/standards-guidelines/wcag/faq/#wcag2ict)**
--   and more...
+-   **Utangazaji wa WCAG 2 wa [ufikiaji wa simu za mkononi](/standards-guidelines/wcag/faq/#mobile)**
+-   **Kutumia WCAG 2 kwa [nyaraka na programu](/standards-guidelines/wcag/faq/#wcag2ict)**
+-   na zaidi...
 
-### JSON machine-readable files {#json-files}
+### Faili za JSON zinazosomeka na mashine {#json-files}
 
-The WCAG JSON (JavaScript Object Notation) files include the principles, guidelines, success criteria, and glossary terms from WCAG and the supporting Techniques. For more information, see [JSON Serialization of WCAG 2 – GitHub {% include_cached external.html %}](https://github.com/w3c/wcag/tree/main/11ty/json#readme).
+Faili za WCAG JSON (JavaScript Object Notation) zinajumuisha kanuni, miongozo, vigezo vya mafanikio, na maneno ya faharasa kutoka WCAG na Mbinu zinazounga mkono. Kwa maelezo zaidi, tazama [Ufuatanishaji wa JSON wa WCAG 2 – GitHub {% include_cached external.html %}](https://github.com/w3c/wcag/tree/main/11ty/json#readme).
 
 ### WCAG 3
 
-For information on the early draft of W3C Accessibility Guidelines 3.0 (formerly known as "Silver"), see the **[WCAG 3 Introduction](/standards-guidelines/wcag/wcag3-intro/)**.
+Kwa maelezo kuhusu rasimu ya mapema ya Miongozo ya Ufikiaji ya W3C 3.0 (zamani ilijulikana kama "Silver"), tazama **[Utangulizi wa WCAG 3](/standards-guidelines/wcag/wcag3-intro/)**.


### PR DESCRIPTION
Translated WCAG 2 Overview page to Swahili, updating titles, descriptions, and other content accordingly.

<!--Describe the pull request below.-->
Adding a new Swahili (`sw`) translation for the WCAG 2 Overview (`index.md`) to expand accessibility guidelines to East African web developers and creators. 

- Translated title, description, and markdown content.
- Preserved all English YAML routing variables, URLs, and Markdown syntax per WAI guidelines.
- Uncommented translator name in front matter.


<!--If your PR has a primary page for review, set an entry path.
    Add a relative path next to `@netlify` below.-->

@netlify /standards-guidelines/wcag/sw