### PR TITLE
Fixes #603

### DIFF
--- a/pages/design-develop/tutorials/images/informative.md
+++ b/pages/design-develop/tutorials/images/informative.md
@@ -45,7 +45,9 @@ In some situations a detailed literal description may be needed, but only when t
 
 ## **Example 1:** Images used to label other information
 
-This example shows two image icons – one of a telephone, one of a fax machine. A phone number follows each image. Consistent with the visual presentation, the text alternatives “Telephone:” and “Fax:” are used to identify the device associated with each number.
+This example shows two image icons – one of a telephone, one of a fax machine. A phone number follows each image.
+
+The text alternatives "Telephone:" and "Fax:" are consistent with the visual presentation: they identify the device associated with each number.
 
 {::nomarkdown}
 {% include box.html type="start" title="Example" class="example" %}
@@ -75,6 +77,15 @@ This example shows two image icons – one of a telephone, one of a fax machine.
 {::nomarkdown}
 {% include box.html type="end" %}
 {:/}
+
+{::nomarkdown}
+{% include box.html type="start" title="Note" class="simple" %}
+{:/}
+The colons after "Telephone:" and "Fax:" provide a pause for the screen reader to separate the label from the number within the paragraph. When considering whether to use a separator or not, it's best to test with a screen reader  to ensure the content is understandable.
+{::nomarkdown}
+{% include box.html type="end" %}
+{:/}
+
 
 ## **Example 2:** Images used to supplement other information
 


### PR DESCRIPTION
Issue #603 asks why there are colons within the alt text for the telephone and fax images. This update explains that the colons cause  the screen reader to pause between the alt text and the provided number.



<!--If your PR has a primary page for review, set an entry path.
    Add a relative path next to `@netlify` below.-->

@netlify /tutorials/images/informative/

References #603