### PR TITLE
fixes #603 colon within alt text

### DIFF
--- a/pages/design-develop/tutorials/images/informative.md
+++ b/pages/design-develop/tutorials/images/informative.md
@@ -45,15 +45,15 @@ In some situations a detailed literal description may be needed, but only when t
 
 ## **Example 1:** Images used to label other information
 
-This example shows two image icons – one of a telephone, one of a fax machine. A phone number follows each image. Consistent with the visual presentation, the text alternatives “Telephone:” and “Fax:” are used to identify the device associated with each number.
+This example shows two image icons – one of a telephone, one of a fax machine. A phone number follows each image. Consistent with the visual presentation, the text alternatives “Telephone” and “Fax” are used to identify the device associated with each number.
 
 {::nomarkdown}
 {% include box.html type="start" title="Example" class="example" %}
 {:/}
 
-![Telephone:]({{ "/content-images/tutorials/images/phone.png" | relative_url }}){:style="vertical-align:middle;"} 0123 456 7890
+![Telephone]({{ "/content-images/tutorials/images/phone.png" | relative_url }}){:style="vertical-align:middle;"} 0123 456 7890
 
-![Fax:]({{ "/content-images/tutorials/images/fax.png" | relative_url }}){:style="vertical-align:middle;"} 0123 456 7891
+![Fax]({{ "/content-images/tutorials/images/fax.png" | relative_url }}){:style="vertical-align:middle;"} 0123 456 7891
 
 {::nomarkdown}
 {% include box.html type="end" %}
@@ -65,10 +65,10 @@ This example shows two image icons – one of a telephone, one of a fax machine.
 
 ~~~ html
 <p>
-  <img src="phone.png" alt="Telephone:"> 0123 456 7890
+  <img src="phone.png" alt="Telephone"> 0123 456 7890
 </p>
 <p>
-  <img src="fax.png" alt="Fax:"> 0123 456 7891
+  <img src="fax.png" alt="Fax"> 0123 456 7891
 </p>
 ~~~
 


### PR DESCRIPTION
Resolves #603 
In example 1 of informative images, the alt text for the phone and fax icons have a colon after each word. This colon is not used after the visible image. Thus, the alt text differs from the visible rendering. The colons have been removed so that the alternative text matches the visual presentation

I did not feel this was significant enough of a change to modify the date or the update the changelog. Please let me know if this is needed.  


<!--If your PR has a primary page for review, set an entry path.
    Add a relative path next to `@netlify` below.-->

@netlify /tutorials/images/informative/