### PR TITLE
fixes 1822 - table irregular headers example 2 code doesn't match cod…

### DIFF
--- a/pages/design-develop/tutorials/changelog.md
+++ b/pages/design-develop/tutorials/changelog.md
@@ -29,6 +29,11 @@ This changelog lists substantive content edits. It does _not_ list typo fixes an
 {% include box.html type="end" %}
 {:/}
 
+## April 2026
+
+In [Tables Tutorial](/tutorials/tables/):
+* Updated the Complete “Table with headers spanning multiple rows or columns” [Example code](/tutorials/tables/examples/scope-multiple/) to match the code in the [Tables with irregular headers](/tutorials/tables/irregular/#table-with-headers-spanning-multiple-rows-or-columns/) Example #2.
+
 ## March 2026
 
 In [Images tutorial](/tutorials/images/):

--- a/pages/design-develop/tutorials/tables/examples/scope-multiple.md
+++ b/pages/design-develop/tutorials/tables/examples/scope-multiple.md
@@ -15,43 +15,52 @@ github:
   <caption>
     Poster availability
   </caption>
-  <tr>
-    <th scope="col">Poster name</th>
-    <th scope="col">Color</th>
-    <th colspan="3" scope="colgroup">Sizes available</th>
+  <col>
+  <col>
+  <colgroup span="3"></colgroup>
+  <thead>
+    <tr>
+      <th scope="col">Poster name</th>
+      <th scope="col">Color</th>
+      <th colspan="3" scope="colgroup">Sizes available</th>
     </tr>
-  <tr>
-    <th rowspan="3" scope="rowgroup">Zodiac</th>
-    <td>Full color</td>
-    <td>A2</td>
-    <td>A3</td>
-    <td>A4</td>
-  </tr>
-  <tr>
-    <td>Black and white</td>
-    <td>A1</td>
-    <td>A2</td>
-    <td>A3</td>
-  </tr>
-  <tr>
-    <td>Sepia</td>
-    <td>A3</td>
-    <td>A4</td>
-    <td>A5</td>
-  </tr>
-  <tr>
-    <th rowspan="2" scope="rowgroup">Angels</th>
-    <td>Black and white</td>
-    <td>A1</td>
-    <td>A3</td>
-    <td>A4</td>
-  </tr>
-  <tr>
-    <td>Sepia</td>
-    <td>A2</td>
-    <td>A3</td>
-    <td>A5</td>
-  </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th rowspan="3" scope="rowgroup">Zodiac</th>
+      <th scope="row">Full color</th>
+      <td>A2</td>
+      <td>A3</td>
+      <td>A4</td>
+    </tr>
+    <tr>
+      <th scope="row">Black and white</th>
+      <td>A1</td>
+      <td>A2</td>
+      <td>A3</td>
+    </tr>
+    <tr>
+      <th scope="row">Sepia</th>
+      <td>A3</td>
+      <td>A4</td>
+      <td>A5</td>
+    </tr>
+</tbody>
+<tbody>
+    <tr>
+      <th rowspan="2" scope="rowgroup">Angels</th>
+      <th scope="row">Black and white</th>
+      <td>A1</td>
+      <td>A3</td>
+      <td>A4</td>
+    </tr>
+    <tr>
+      <th scope="row">Sepia</th>
+      <td>A2</td>
+      <td>A3</td>
+      <td>A5</td>
+    </tr>
+</tbody>
 </table>
 
 ~~~


### PR DESCRIPTION
…e on main page
Resolves #1822
table irregular headers example 2 code doesn't match code on main page

<!--Describe the pull request below.-->
Example #2 in the Tables > Irregular Headers page contains a link to the full code. This code appears to be just the snippet and the code in the main tutorial page is the full code rather than vice versa.  Rather than modify/shorten the existing "snippet" on the main page and cause more confusion, I updated the example code to match this full code. The full example code link now contains the correct, full code. 

I also updated the changelog since this would affect anyone who was using the example code. 

<!--If your PR has a primary page for review, set an entry path.
    Add a relative path next to `@netlify` below.-->

@netlify /tutorials/tables/irregular/