### PR TITLE
Resolves #616 remove reference to removed WCAG Technique H4

### DIFF
--- a/pages/design-develop/tutorials/changelog.md
+++ b/pages/design-develop/tutorials/changelog.md
@@ -31,6 +31,9 @@ This changelog lists substantive content edits. It does _not_ list typo fixes an
 
 ## April 2026
 
+In [Menus tutorial](/tutorials/menu)
+* Removed references to WCAG Technique H4 concerning logical tab order. It is marked as obsolte and not referenced from any Understanding document. [PR 1954](https://github.com/w3c/wai-website/pull/1954)
+
 Removed references to the deprecated `longdesc` attribute. [GitHub PR #1870](https://github.com/w3c/wai-website/pull/1870) and [PR #1942](https://github.com/w3c/wai-website/pull/1942)
 * In [Images tutorial](/tutorials/images/)
     * Removed the section about and references to `longdesc` in the code from [Complex Images](/tutorials/images/complex/)

--- a/pages/design-develop/tutorials/changelog.md
+++ b/pages/design-develop/tutorials/changelog.md
@@ -31,10 +31,10 @@ This changelog lists substantive content edits. It does _not_ list typo fixes an
 
 ## April 2026
 
-In [Menus tutorial](/tutorials/menu)
-* Removed references to WCAG Technique H4 concerning logical tab order. It is marked as obsolte and not referenced from any Understanding document. [PR 1954](https://github.com/w3c/wai-website/pull/1954)
+In [Menus tutorial](/tutorials/menus/):
+* Removed references to WCAG Technique H4 concerning logical tab order. It is marked as obsolete and not referenced from any Understanding document. [GitHub PR #1954](https://github.com/w3c/wai-website/pull/1954)
 
-Removed references to the deprecated `longdesc` attribute. [GitHub PR #1870](https://github.com/w3c/wai-website/pull/1870) and [PR #1942](https://github.com/w3c/wai-website/pull/1942)
+Removed references to the deprecated `longdesc` attribute — [GitHub PR #1870](https://github.com/w3c/wai-website/pull/1870) and [PR #1942](https://github.com/w3c/wai-website/pull/1942):
 * In [Images tutorial](/tutorials/images/)
     * Removed the section about and references to `longdesc` in the code from [Complex Images](/tutorials/images/complex/)
 * In [Page Structure tutorial](/tutorials/page-structure/)

--- a/pages/design-develop/tutorials/index.md
+++ b/pages/design-develop/tutorials/index.md
@@ -3,7 +3,7 @@ title: "Tutorials"
 permalink: /tutorials/
 ref: /tutorials/
 lang: en
-last_updated: 2026-04-08
+last_updated: 2026-04-13
 first_published: "September 2014"
 
 github:

--- a/pages/design-develop/tutorials/menus/flyout.md
+++ b/pages/design-develop/tutorials/menus/flyout.md
@@ -17,7 +17,7 @@ wcag_techniques:
   - SCR26
 
 metafooter: true
-last_updated: 2026-04-14
+last_updated: 2026-04-13
 editors:
   - Eric Eggert: "https://www.w3.org/People/yatil/"
   - Shadi Abou-Zahra: "https://www.w3.org/People/shadi/"

--- a/pages/design-develop/tutorials/menus/flyout.md
+++ b/pages/design-develop/tutorials/menus/flyout.md
@@ -17,7 +17,7 @@ wcag_techniques:
   - SCR26
 
 metafooter: true
-last_updated: 2022-02-08
+last_updated: 2026-04-14
 editors:
   - Eric Eggert: "https://www.w3.org/People/yatil/"
   - Shadi Abou-Zahra: "https://www.w3.org/People/shadi/"

--- a/pages/design-develop/tutorials/menus/flyout.md
+++ b/pages/design-develop/tutorials/menus/flyout.md
@@ -15,7 +15,6 @@ navigation:
 
 wcag_techniques:
   - SCR26
-  - H4
 
 metafooter: true
 last_updated: 2022-02-08

--- a/pages/design-develop/tutorials/menus/index.md
+++ b/pages/design-develop/tutorials/menus/index.md
@@ -34,7 +34,7 @@ wcag_techniques:
 
 metafooter: true
 first_published: "May 2015"
-last_updated: 2026-04-14
+last_updated: 2026-04-13
 editors:
   - Eric Eggert: "https://www.w3.org/People/yatil/"
   - Shadi Abou-Zahra: "https://www.w3.org/People/shadi/"

--- a/pages/design-develop/tutorials/menus/index.md
+++ b/pages/design-develop/tutorials/menus/index.md
@@ -34,7 +34,7 @@ wcag_techniques:
 
 metafooter: true
 first_published: "May 2015"
-last_updated: 2017-04-13
+last_updated: 2026-04-14
 editors:
   - Eric Eggert: "https://www.w3.org/People/yatil/"
   - Shadi Abou-Zahra: "https://www.w3.org/People/shadi/"

--- a/pages/design-develop/tutorials/menus/index.md
+++ b/pages/design-develop/tutorials/menus/index.md
@@ -20,7 +20,6 @@ wcag_success_criteria:
   - 2.4.8
   - 4.1.2
 wcag_techniques:
-  - H4
   - SCR26
   - G65
   - G161


### PR DESCRIPTION
Resolves #616
Remove reference to WCAG Technique H4 from tutorials as it has been removed from WCAG.
Removed from: tutorials/menus and tutorials/menus/flyout/ 

As I a minor update, I did not update the last_updated variable nor the changelog. 


@netlify /tutorials/menus/