### PR TITLE
update content to match WCAG-EM 2 terminology

### DIFF
--- a/pages/test-evaluate/conformance/wcag-em.md
+++ b/pages/test-evaluate/conformance/wcag-em.md
@@ -160,7 +160,7 @@ Text Transcript with Description of Visuals
 
 ## Introduction
 
-Website Accessibility Conformance Evaluation Methodology (WCAG-EM) is an approach for determining how well a digital product conforms to Web Content Accessibility Guidelines ([WCAG](/standards-guidelines/wcag/)).
+WCAG Evaluation Methodology (WCAG-EM) is an approach for determining how well a digital product conforms to Web Content Accessibility Guidelines ([WCAG](/standards-guidelines/wcag/)).
 
 If you want to get a general sense of how a web page or view addresses a few accessibility issues, see [Easy Checks - A First Review of Web Accessibility](/test-evaluate/preliminary/). It is usually best to do preliminary checks before applying WCAG-EM, and to address potential accessibility barriers before investing in a more thorough review such as WCAG-EM.
 

--- a/pages/test-evaluate/conformance/wcag-em.md
+++ b/pages/test-evaluate/conformance/wcag-em.md
@@ -158,45 +158,28 @@ Text Transcript with Description of Visuals
 
 {% include excol.html type="end" %}
 
-## Update: WCAG-EM 2 Draft
-
-W3C Accessibility Guidelines Evaluation Methodology (WCAG-EM) 2 is an in-progress draft for review. What's different:
-- WCAG-EM 1 is specifically for testing websites and web pages.
-- WCAG-EM 2 also applies to apps and other digital products.
-
-For more information on the differences, see the WCAG-EM 2 [Changelog (GitHub)](https://github.com/w3c/wai-wcag-em/?tab=readme-ov-file#changelog).
-
-We invite you to review and comment on this draft.
-- Are all digital products that evaluators commonly evaluate covered by this methodology, or are any explicitly excluded?
-- Does the terminology of 'sample set' and 'sample' match how evaluators use it in their evaluations?
-- Is this new version more useful for evaluators when they evaluate apps?
-
-To comment, please open a new issue in the [wai-wcag-em GitHub repository](https://github.com/w3c/wai-wcag-em/). Create a separate GitHub issue for each topic, rather than commenting on multiple topics in a single issue. If it's not feasible for you to use GitHub, email your comments to public-agwg-comments@w3.org Please put your comments in the body of the message, not as an attachment.
-
-_The rest of this page covers WCAG-EM 1. It also applies to WCAG-EM 2._
-
 ## Introduction
 
-Website Accessibility Conformance Evaluation Methodology (WCAG-EM) 1 is an approach for determining how well a website conforms to Web Content Accessibility Guidelines ([WCAG](/standards-guidelines/wcag/)).
+Website Accessibility Conformance Evaluation Methodology (WCAG-EM) is an approach for determining how well a digital product conforms to Web Content Accessibility Guidelines ([WCAG](/standards-guidelines/wcag/)).
 
-If you want to get a general sense of how a web page addresses a few accessibility issues, see [Easy Checks - A First Review of Web Accessibility](/test-evaluate/preliminary/). It is usually best to do preliminary checks before applying WCAG-EM, and to address potential accessibility barriers before investing in a more thorough review such as WCAG-EM.
+If you want to get a general sense of how a web page or view addresses a few accessibility issues, see [Easy Checks - A First Review of Web Accessibility](/test-evaluate/preliminary/). It is usually best to do preliminary checks before applying WCAG-EM, and to address potential accessibility barriers before investing in a more thorough review such as WCAG-EM.
 
 WCAG-EM is a supporting resource for the WCAG standard; it does not define additional WCAG requirements. It is published as a W3C Working Group Note.
 
 ### Scope
 
-WCAG-EM applies to all websites, including web applications and mobile websites. It covers different situations, including self-assessment and third-party evaluation. It is independent of particular evaluation tools, web browsers, or assistive technologies.
+WCAG-EM can be applied to all digital products, including websites, mobile applications and kiosks. It covers different situations, including self-assessment and third-party evaluation. It is independent of particular evaluation tools, web browsers, or assistive technologies.
 
-WCAG-EM is primarily for evaluating conformance of existing websites. However, accessibility should not be left until the evaluation stage; it should be integrated from the beginning and throughout the project lifecycle — in planning, design, and development.
+WCAG-EM is primarily for evaluating conformance of existing digital products. However, accessibility should not be left until the evaluation stage; it should be integrated from the beginning and throughout the project lifecycle — in planning, design, and development.
 
 Other aspects of evaluation are addressed in related pages of the [Evaluating Web Accessibility](/test-evaluate/) resource suite. For example, guidance to help you better understand real-world accessibility issues and evaluate effective accessibility solutions is in [Involving Users in Evaluating Web Accessibility](/test-evaluate/involving-users/).
 
 Who WCAG-EM is for {#for}
 --------------------------
 
-WCAG-EM is for anyone who wants a common procedure for auditing websites. It is for direct use by internal evaluators, external auditors, benchmarkers, and researchers. Additionally, WCAG-EM can be referred to by managers, procurers, policy makers, regulators, and others. 
+WCAG-EM is for anyone who wants a common procedure for auditing digital products, like websites. It is for direct use by internal evaluators, external auditors, benchmarkers, and researchers. Additionally, WCAG-EM can be referred to by managers, procurers, policy makers, regulators, and others. 
 
-Applying WCAG-EM successfully requires knowledge of WCAG, accessible web design, assistive technologies, and how people with different disabilities use the Web (as described in the WCAG-EM [Required Expertise section](https://www.w3.org/TR/WCAG-EM/#expertise)).
+Applying WCAG-EM successfully requires knowledge of WCAG, accessible design, assistive technologies, and how people with different disabilities use digital products (as described in the WCAG-EM [Required Expertise section](https://www.w3.org/TR/WCAG-EM/#expertise)).
 
 What is in WCAG-EM {#whatis}
 -----------------------------
@@ -204,9 +187,9 @@ What is in WCAG-EM {#whatis}
 WCAG-EM provides guidance on using the methodology and considerations for specific situations. The conformance evaluation procedure is detailed under 5 main steps:
 
 1.  **Define the scope of the evaluation** - defining what is included in the evaluation; the goal of the evaluation; and the WCAG conformance level (A, AA, AAA).
-2.  **Explore the website** - identifying key web pages; key functionality; types of web content, designs, functionality, etc.; required web technologies.
-3.  **Select a representative sample** - guidance on structured and randomly selected web pages when it is not feasible to evaluate every web page on a website.
-4.  **Evaluate the selected sample** - determining successes and failures in meeting WCAG; accessibility support for website features; and recording evaluation steps.
+2.  **Explore the product** - identifying key views; key functionality; types of content, designs, functionality, etc.; required technologies.
+3.  **Select a representative sample** - guidance on structured and randomly selected views when it is not feasible to evaluate every view in a digital product.
+4.  **Evaluate the selected sample** - determining successes and failures in meeting WCAG; accessibility support for specific features; and recording evaluation steps.
 5.  **Report the evaluation findings** - aggregating and reporting evaluation findings; making evaluation statements; and calculating overall scores.
 
 ### Technical document format
@@ -217,6 +200,20 @@ WCAG-EM Report Tool {#wert}
 ----------------------------
 
 The [**WCAG-EM Report Tool: Website Accessibility Evaluation Report Generator**](https://www.w3.org/WAI/eval/report-tool/) helps you follow the steps of WCAG-EM and generate a structured report from the input that you provide.
+
+WCAG-EM 2 vs WCAG-EM {#versiondiff}
+-----------------------
+
+W3C Accessibility Guidelines Evaluation Methodology (WCAG-EM) 2 was published on @@@ and supersedes WCAG-EM 1. 
+
+What's different:
+
+- WCAG-EM was specifically for testing websites and web pages.
+- WCAG-EM 2 also applies to apps and other digital products.
+
+For more information on the differences, see the WCAG-EM 2 [Changelog (GitHub)](https://github.com/w3c/wai-wcag-em/?tab=readme-ov-file#changelog).
+
+The [1.0 version of WCAG-EM](https://www.w3.org/TR/2014/NOTE-WCAG-EM-20140710/) is still available.
 
 Who develops WCAG-EM {#wg}
 ---------------------------

--- a/pages/test-evaluate/conformance/wcag-em.md
+++ b/pages/test-evaluate/conformance/wcag-em.md
@@ -204,7 +204,7 @@ The [**WCAG-EM Report Tool: Website Accessibility Evaluation Report Generator**]
 WCAG-EM 2 vs WCAG-EM {#versiondiff}
 -----------------------
 
-W3C Accessibility Guidelines Evaluation Methodology (WCAG-EM) 2 was published on @@@ and supersedes WCAG-EM 1. 
+W3C Accessibility Guidelines Evaluation Methodology (WCAG-EM) 2 was published on 23 July 2026. 
 
 What's different:
 

--- a/pages/test-evaluate/conformance/wcag-em.md
+++ b/pages/test-evaluate/conformance/wcag-em.md
@@ -2,8 +2,8 @@
 # Translation instructions are after the "#" character in this first section. They are comments that do not show up in the web page. You do not need to translate the instructions after "#".
 # In this first section, do not translate the words before a colon. For example, do not translate "title:". Do translate the text after "title:".
 title: "WCAG-EM Overview: Website Accessibility Conformance Evaluation Methodology"
-title_html: "WCAG-EM Overview:<br>Website Accessibility Conformance Evaluation Methodology"
-nav_title: "WCAG-EM Conformance Methodology"
+title_html: "WCAG-EM Overview:<brW3C Accessibility Guidelines Evaluation Methodology"
+nav_title: "WCAG-EM Evaluation Methodology"
 lang: en  # Change "en" to the translated-language shortcode
 last_updated: 2026-02-05  # Keep the date of the English version
 first_published: "as “Conformance Evaluation of Web Sites for Accessibility” in September 2005"
@@ -36,12 +36,11 @@ footer: >
 {% include box.html type="start" h="2" title="Summary" class="full" %}
 {:/}
 
-This page introduces the Website Accessibility Conformance Evaluation Methodology (WCAG-EM).
+This page introduces the W3C Accessibility Guidelines Evaluation Methodology (WCAG-EM).
 
 Quick links to the resources:
 
--   [Website Accessibility Conformance Evaluation Methodology (WCAG-EM) 1.0](http://www.w3.org/TR/WCAG-EM/)
--   [Draft W3C Accessibility Guidelines Evaluation Methodology (WCAG-EM) 2.0](https://www.w3.org/TR/wcag-em-2/)
+-   [W3C Accessibility Guidelines Evaluation Methodology (WCAG-EM) 2.0](https://www.w3.org/TR/wcag-em-2/)
 -   [WCAG-EM Report Tool: Website Accessibility Evaluation Report Generator](http://www.w3.org/WAI/eval/report-tool/)
 
 {::nomarkdown}
@@ -164,13 +163,13 @@ WCAG Evaluation Methodology (WCAG-EM) is an approach for determining how well a 
 
 If you want to get a general sense of how a web page or view addresses a few accessibility issues, see [Easy Checks - A First Review of Web Accessibility](/test-evaluate/preliminary/). It is usually best to do preliminary checks before applying WCAG-EM, and to address potential accessibility barriers before investing in a more thorough review such as WCAG-EM.
 
-WCAG-EM is a supporting resource for the WCAG standard; it does not define additional WCAG requirements. It is published as a W3C Working Group Note.
+WCAG-EM is a supporting resource for the WCAG standard; it does not define additional WCAG requirements. It is published as a W3C Group Note.
 
 ### Scope
 
-WCAG-EM can be applied to all digital products, including websites, mobile applications and kiosks. It covers different situations, including self-assessment and third-party evaluation. It is independent of particular evaluation tools, web browsers, or assistive technologies.
+WCAG-EM can be applied to all digital products, including websites, mobile applications, and kiosks. It covers different situations, including self-assessment and third-party evaluation. It is independent of particular evaluation tools, web browsers, or assistive technologies.
 
-WCAG-EM is primarily for evaluating conformance of existing digital products. However, accessibility should not be left until the evaluation stage; it should be integrated from the beginning and throughout the project lifecycle — in planning, design, and development.
+WCAG-EM is primarily for evaluating conformance of existing digital products. However, accessibility should not be left until the evaluation stage. Accessibility should be integrated from the beginning and throughout the project lifecycle — in planning, design, and development.
 
 Other aspects of evaluation are addressed in related pages of the [Evaluating Web Accessibility](/test-evaluate/) resource suite. For example, guidance to help you better understand real-world accessibility issues and evaluate effective accessibility solutions is in [Involving Users in Evaluating Web Accessibility](/test-evaluate/involving-users/).
 
@@ -179,7 +178,7 @@ Who WCAG-EM is for {#for}
 
 WCAG-EM is for anyone who wants a common procedure for auditing digital products, like websites. It is for direct use by internal evaluators, external auditors, benchmarkers, and researchers. Additionally, WCAG-EM can be referred to by managers, procurers, policy makers, regulators, and others. 
 
-Applying WCAG-EM successfully requires knowledge of WCAG, accessible design, assistive technologies, and how people with different disabilities use digital products (as described in the WCAG-EM [Required Expertise section](https://www.w3.org/TR/WCAG-EM/#expertise)).
+Applying WCAG-EM successfully requires knowledge of WCAG, accessible design, assistive technologies, and how people with different disabilities use digital products. This is  described in the WCAG-EM [Required Expertise section](https://www.w3.org/TR/WCAG-EM/#expertise).
 
 What is in WCAG-EM {#whatis}
 -----------------------------
@@ -199,16 +198,16 @@ WCAG-EM follows the W3C format for technical specifications which includes sever
 WCAG-EM Report Tool {#wert}
 ----------------------------
 
-The [**WCAG-EM Report Tool: Website Accessibility Evaluation Report Generator**](https://www.w3.org/WAI/eval/report-tool/) helps you follow the steps of WCAG-EM and generate a structured report from the input that you provide.
+The [**WCAG-EM Report Tool: Website Accessibility Evaluation Report Generator**](https://www.w3.org/WAI/eval/report-tool/) helps you follow the steps of WCAG-EM and generate a structured report from the input that you provide. The tool is currently for WCAG-EM 1. We plan to provide an updated WCAG-EM 2 Report Tool later in 2026.
 
-WCAG-EM 2 vs WCAG-EM {#versiondiff}
+WCAG-EM 2 and WCAG-EM 1 {#versiondiff}
 -----------------------
 
 W3C Accessibility Guidelines Evaluation Methodology (WCAG-EM) 2 was published on 23 July 2026. 
 
 What's different:
 
-- WCAG-EM was specifically for testing websites and web pages.
+- WCAG-EM 1 was specifically for testing websites and web pages.
 - WCAG-EM 2 also applies to apps and other digital products.
 
 For more information on the differences, see the WCAG-EM 2 [Changelog (GitHub)](https://github.com/w3c/wai-wcag-em/?tab=readme-ov-file#changelog).

--- a/pages/test-evaluate/conformance/wcag-em.md
+++ b/pages/test-evaluate/conformance/wcag-em.md
@@ -2,7 +2,7 @@
 # Translation instructions are after the "#" character in this first section. They are comments that do not show up in the web page. You do not need to translate the instructions after "#".
 # In this first section, do not translate the words before a colon. For example, do not translate "title:". Do translate the text after "title:".
 title: "WCAG-EM Overview: Website Accessibility Conformance Evaluation Methodology"
-title_html: "WCAG-EM Overview:<br>W3C Accessibility Guidelines Evaluation Methodology"
+title_html: "WCAG-EM Overview:<br>WCAG Evaluation Methodology"
 nav_title: "WCAG-EM Evaluation Methodology"
 lang: en  # Change "en" to the translated-language shortcode
 last_updated: 2026-07-23  # Keep the date of the English version
@@ -36,11 +36,11 @@ footer: >
 {% include box.html type="start" h="2" title="Summary" class="full" %}
 {:/}
 
-This page introduces the W3C Accessibility Guidelines Evaluation Methodology (WCAG-EM).
+This page introduces the WCAG Evaluation Methodology (WCAG-EM).
 
 Quick links to the resources:
 
--   [W3C Accessibility Guidelines Evaluation Methodology (WCAG-EM) 2.0](https://www.w3.org/TR/wcag-em-2/)
+-   [WCAG Evaluation Methodology (WCAG-EM) 2.0](https://www.w3.org/TR/wcag-em-2/)
 -   [WCAG-EM Report Tool: Website Accessibility Evaluation Report Generator](http://www.w3.org/WAI/eval/report-tool/)
 
 {::nomarkdown}

--- a/pages/test-evaluate/conformance/wcag-em.md
+++ b/pages/test-evaluate/conformance/wcag-em.md
@@ -203,7 +203,7 @@ The [**WCAG-EM Report Tool: Website Accessibility Evaluation Report Generator**]
 WCAG-EM 2 and WCAG-EM 1 {#versiondiff}
 -----------------------
 
-W3C Accessibility Guidelines Evaluation Methodology (WCAG-EM) 2 was published on 23 July 2026. 
+WCAG Evaluation Methodology (WCAG-EM) 2 was published on 23 July 2026. 
 
 What's different:
 

--- a/pages/test-evaluate/conformance/wcag-em.md
+++ b/pages/test-evaluate/conformance/wcag-em.md
@@ -2,7 +2,7 @@
 # Translation instructions are after the "#" character in this first section. They are comments that do not show up in the web page. You do not need to translate the instructions after "#".
 # In this first section, do not translate the words before a colon. For example, do not translate "title:". Do translate the text after "title:".
 title: "WCAG-EM Overview: Website Accessibility Conformance Evaluation Methodology"
-title_html: "WCAG-EM Overview:<brW3C Accessibility Guidelines Evaluation Methodology"
+title_html: "WCAG-EM Overview:<br>W3C Accessibility Guidelines Evaluation Methodology"
 nav_title: "WCAG-EM Evaluation Methodology"
 lang: en  # Change "en" to the translated-language shortcode
 last_updated: 2026-02-05  # Keep the date of the English version

--- a/pages/test-evaluate/conformance/wcag-em.md
+++ b/pages/test-evaluate/conformance/wcag-em.md
@@ -5,7 +5,7 @@ title: "WCAG-EM Overview: Website Accessibility Conformance Evaluation Methodolo
 title_html: "WCAG-EM Overview:<br>W3C Accessibility Guidelines Evaluation Methodology"
 nav_title: "WCAG-EM Evaluation Methodology"
 lang: en  # Change "en" to the translated-language shortcode
-last_updated: 2026-02-05  # Keep the date of the English version
+last_updated: 2026-07-23  # Keep the date of the English version
 first_published: "as “Conformance Evaluation of Web Sites for Accessibility” in September 2005"
 
 # translators: # remove from the beginning of this line and the lines below: "# " (the hash sign and the space)


### PR DESCRIPTION
<!--Describe the pull request below.-->

As part of preparing publication of WCAG-EM 2 to supersede 1.0, this PR: 

- updates references to WCAG-EM 1 terminology (like website) to WCAG-EM 2 terminology (like digital product)
- removes draft review questions section
- adds 'what's different between 1 and 2' section with permanent link to 1.0


<!--If your PR has a primary page for review, set an entry path.
    Add a relative path next to `@netlify` below.-->

@netlify /