### PR TITLE
list-submission function: Add Cloudflare Turnstile processing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,6 @@ gem 'jekyll-feed', '~>0.17.0'
 
 # Gems loaded irrespective of site configuration.
 group :jekyll_plugins do
-    gem 'wai-website-theme', git: 'https://github.com/w3c/wai-website-theme', branch: 'main' # The theme of the site
+    gem 'wai-website-theme', git: 'https://github.com/w3c/wai-website-theme', branch: 'kgf-turnstile' # The theme of the site
     gem 'wai-website-plugin', git: 'https://github.com/w3c/wai-website-plugin', branch: 'main' # The Jekyll plugins needed by the theme
 end

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,6 @@ gem 'jekyll-feed', '~>0.17.0'
 
 # Gems loaded irrespective of site configuration.
 group :jekyll_plugins do
-    gem 'wai-website-theme', git: 'https://github.com/w3c/wai-website-theme', branch: 'kgf-turnstile' # The theme of the site
+    gem 'wai-website-theme', git: 'https://github.com/w3c/wai-website-theme', branch: 'main' # The theme of the site
     gem 'wai-website-plugin', git: 'https://github.com/w3c/wai-website-plugin', branch: 'main' # The Jekyll plugins needed by the theme
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 
 GIT
   remote: https://github.com/w3c/wai-website-theme
-  revision: 468c42cf13a29f4921df47caae7abc35269a77ff
+  revision: fe72f85ae8d70172d08949d95d4bdca805222cf6
   branch: main
   specs:
     wai-website-theme (1.10)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,8 +9,8 @@ GIT
 
 GIT
   remote: https://github.com/w3c/wai-website-theme
-  revision: d391719682fc100fd2f307b6825178685bd3164c
-  branch: kgf-turnstile
+  revision: 468c42cf13a29f4921df47caae7abc35269a77ff
+  branch: main
   specs:
     wai-website-theme (1.10)
       jekyll (~> 4.4.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,8 +9,8 @@ GIT
 
 GIT
   remote: https://github.com/w3c/wai-website-theme
-  revision: 468c42cf13a29f4921df47caae7abc35269a77ff
-  branch: main
+  revision: d391719682fc100fd2f307b6825178685bd3164c
+  branch: kgf-turnstile
   specs:
     wai-website-theme (1.10)
       jekyll (~> 4.4.1)

--- a/_functions/list-submission.js
+++ b/_functions/list-submission.js
@@ -162,7 +162,9 @@ exports.handler = async function (event, context) {
     event.headers["CF-Connecting-IP"] ||
       event.headers["X-Forwarded-For"] ||
       "unknown",
-    formData['DEBUG'] || module === require.main
+    (process.env.CONTEXT && process.env.CONTEXT !== "production") ||
+      module === require.main ||
+      formData['DEBUG']
   );
   if (!turnstileResult.success) {
     console.error(`Rejecting form submission which failed Turnstile challenge`);

--- a/_functions/list-submission.js
+++ b/_functions/list-submission.js
@@ -69,6 +69,38 @@ function callGitHubWebhook(formData) {
   })
 }
 
+/**
+ * Validates turnstile tokens;
+ * see https://developers.cloudflare.com/turnstile/get-started/server-side-validation/#form-data
+ * @param {string} response The response value sent by the Turnstile widget
+ * @param {string} remoteip End-user IP that accessed the page
+ * @param {boolean} isTesting Whether to use the test secret key instead of the real one
+ */
+async function validateTurnstile(response, remoteip, isTesting) {
+  const body = new FormData();
+
+  if (isTesting)
+    body.append("secret", "1x0000000000000000000000000000000AA"); // Always succeeds
+  else if (process.env.TURNSTILE_SECRET)
+    body.append("secret", process.env.TURNSTILE_SECRET);
+  else
+    console.warn("WARNING: TURNSTILE_SECRET environment variable not set in a non-testing environment!")
+
+  body.append("response", response);
+  body.append("remoteip", remoteip);
+
+  try {
+    const response = await fetch(
+      "https://challenges.cloudflare.com/turnstile/v0/siteverify",
+      { method: "POST", body }
+    );
+    return await response.json();
+  } catch (error) {
+    console.error("Turnstile validation error:", error);
+    return { success: false, "error-codes": ["internal-error"] };
+  }
+}
+
 function formEncodedToPOJO(formEncoded) {
   const form = new URLSearchParams(formEncoded)
   return Array.from(form.keys()).reduce((result, key) => {
@@ -124,6 +156,18 @@ exports.handler = async function (event, context) {
   }
 
   const formData = formEncodedToPOJO(event.body)
+
+  const turnstileResult = await validateTurnstile(
+    formData["cf-turnstile-response"],
+    event.headers["CF-Connecting-IP"] ||
+      event.headers["X-Forwarded-For"] ||
+      "unknown",
+    formData['DEBUG'] || module === require.main
+  );
+  if (!turnstileResult.success) {
+    console.error(`Rejecting form submission which failed Turnstile challenge`);
+    return { statusCode: 400, body: "Form submission failed challenge validation" };
+  }
 
   if (!(formData.repository in requiredKeys)) {
     console.error(`Rejecting form submission for invalid repository ${formData.repository}`);


### PR DESCRIPTION
This adds server-side validation for the Cloudflare Turnstile widget introduced in https://github.com/w3c/wai-website-theme/pull/216.

## TODOs before merging

* [x] Adjust second argument passed to `validateTurnstile` so that PR previews will use the test key
* [x] Revert wai-website-theme Gemspec change

@netlify /test-evaluate/tools/submit-a-tool/