### PR TITLE
Translation support information

### DIFF
--- a/pages/about/translating.md
+++ b/pages/about/translating.md
@@ -53,7 +53,7 @@ For a list of existing translations, see [All WAI Translations](/translations/).
 {:/}
 **W3C staff temporarily has limited availability to support WAI translations.**
 
-We expect to resume full support in early November 2026. Thank you very much for your patience, if we are not able to reply to you until then. We greatly appreciate contributions and look forward to supporting you as soon as possible.
+We expect to resume full support by late October 2026. Thank you very much for your patience, if we are not able to reply to you until then. We greatly appreciate contributions and look forward to supporting you as soon as possible.
 
 To receive updates, subscribe to the WAI Translations mailing list by sending an e-mail to <public-wai-translations-request@w3.org> with subject: “subscribe”.
 

--- a/pages/about/translating.md
+++ b/pages/about/translating.md
@@ -48,6 +48,20 @@ For a list of existing translations, see [All WAI Translations](/translations/).
 {% include_cached toc.html type="end" %}
 {:/}
 
+{::nomarkdown}
+{% include box.html type="start" class="highlighted" %}
+{:/}
+**W3C staff temporarily has limited availability to support WAI translations.**
+
+We expect to resume full support in early November 2026. Thank you very much for your patience, if we are not able to reply to you until then. We greatly appreciate contributions and look forward to supporting you as soon as possible.
+
+To receive updates, subscribe to the WAI Translations mailing list by sending an e-mail to <public-wai-translations-request@w3.org> with subject: “subscribe”.
+
+For time-sensitive requests, contact <wai@w3.org>.
+
+{::nomarkdown}
+{% include box.html type="end" %}
+{:/}
 
 ## Ways to contribute
 

--- a/pages/about/translating/resources.md
+++ b/pages/about/translating/resources.md
@@ -50,13 +50,13 @@ To get announcements related to WAI translations, subscribe to the WAI Translati
 {::nomarkdown}
 {% include box.html type="start" class="highlighted" %}
 {:/}
-**Translation development is temporarily on hold.** 
+**W3C staff temporarily has limited availability to support WAI translations.** 
+
+We expect to resume full support in early November 2026. Thank you very much for your patience, if we are not able to reply to you until then. We greatly appreciate contributions and look forward to supporting you as soon as possible.
+
+To receive updates, subscribe to the WAI Translations mailing list by sending an e-mail to <public-wai-translations-request@w3.org> with subject: “subscribe”.
 
 For time-sensitive requests, contact <wai@w3.org>.
-
-To be notified when support resumes, subcribe to the WAI Translations mailing list by sending e-mail to <public-wai-translations-request@w3.org> with subject: “subscribe”.
-
-Thank you for your patience. We truly value your contributions and look forward to supporting you again soon.
 
 {::nomarkdown}
 {% include box.html type="end" %}

--- a/pages/about/translating/resources.md
+++ b/pages/about/translating/resources.md
@@ -47,7 +47,22 @@ To get announcements related to WAI translations, subscribe to the WAI Translati
 {% include_cached toc.html type="end" %}
 {:/}
 
-## Overview 
+{::nomarkdown}
+{% include box.html type="start" class="highlighted" %}
+{:/}
+**Translation development is temporarily on hold.** 
+
+For time-sensitive requests, contact <wai@w3.org>.
+
+To be notified when support resumes, subcribe to the WAI Translations mailing list by sending e-mail to <public-wai-translations-request@w3.org> with subject: “subscribe”.
+
+Thank you for your patience. We truly value your contributions and look forward to supporting you again soon.
+
+{::nomarkdown}
+{% include box.html type="end" %}
+{:/}
+
+## Overview
 
 There are 6 steps to contribute as a volunteer translator:
 

--- a/pages/about/translating/resources.md
+++ b/pages/about/translating/resources.md
@@ -52,7 +52,7 @@ To get announcements related to WAI translations, subscribe to the WAI Translati
 {:/}
 **W3C staff temporarily has limited availability to support WAI translations.** 
 
-We expect to resume full support in early November 2026. Thank you very much for your patience, if we are not able to reply to you until then. We greatly appreciate contributions and look forward to supporting you as soon as possible.
+We expect to resume full support by late October 2026. Thank you very much for your patience, if we are not able to reply to you until then. We greatly appreciate contributions and look forward to supporting you as soon as possible.
 
 To receive updates, subscribe to the WAI Translations mailing list by sending an e-mail to <public-wai-translations-request@w3.org> with subject: “subscribe”.
 

--- a/pages/about/translating/resources/images.md
+++ b/pages/about/translating/resources/images.md
@@ -47,7 +47,7 @@ This page guides you through the technical steps to translate images from the We
 {:/}
 **W3C staff temporarily has limited availability to support WAI translations.**
 
-We expect to resume full support in early November 2026. Thank you very much for your patience, if we are not able to reply to you until then. We greatly appreciate contributions and look forward to supporting you as soon as possible.
+We expect to resume full support by late October 2026. Thank you very much for your patience, if we are not able to reply to you until then. We greatly appreciate contributions and look forward to supporting you as soon as possible.
 
 To receive updates, subscribe to the WAI Translations mailing list by sending an e-mail to <public-wai-translations-request@w3.org> with subject: “subscribe”.
 

--- a/pages/about/translating/resources/images.md
+++ b/pages/about/translating/resources/images.md
@@ -42,6 +42,21 @@ This page guides you through the technical steps to translate images from the We
 {% include toc.html type="end" %}
 {:/}
 
+{::nomarkdown}
+{% include box.html type="start" class="highlighted" %}
+{:/}
+**W3C staff temporarily has limited availability to support WAI translations.**
+
+We expect to resume full support in early November 2026. Thank you very much for your patience, if we are not able to reply to you until then. We greatly appreciate contributions and look forward to supporting you as soon as possible.
+
+To receive updates, subscribe to the WAI Translations mailing list by sending an e-mail to <public-wai-translations-request@w3.org> with subject: “subscribe”.
+
+For time-sensitive requests, contact <wai@w3.org>.
+
+{::nomarkdown}
+{% include box.html type="end" %}
+{:/}
+
 ## Overview
 
 There are 3 steps to create translated versions of our resources' images:

--- a/pages/about/translating/resources/resource-specific-instructions.md
+++ b/pages/about/translating/resources/resource-specific-instructions.md
@@ -42,6 +42,21 @@ This page provides specific translation instructions for some WAI resources.
 {:/}
 
 {::nomarkdown}
+{% include box.html type="start" class="highlighted" %}
+{:/}
+**W3C staff temporarily has limited availability to support WAI translations.**
+
+We expect to resume full support in early November 2026. Thank you very much for your patience, if we are not able to reply to you until then. We greatly appreciate contributions and look forward to supporting you as soon as possible.
+
+To receive updates, subscribe to the WAI Translations mailing list by sending an e-mail to <public-wai-translations-request@w3.org> with subject: “subscribe”.
+
+For time-sensitive requests, contact <wai@w3.org>.
+
+{::nomarkdown}
+{% include box.html type="end" %}
+{:/}
+
+{::nomarkdown}
 {% include excol.html type="all" %}
 {:/}
 

--- a/pages/about/translating/resources/resource-specific-instructions.md
+++ b/pages/about/translating/resources/resource-specific-instructions.md
@@ -46,7 +46,7 @@ This page provides specific translation instructions for some WAI resources.
 {:/}
 **W3C staff temporarily has limited availability to support WAI translations.**
 
-We expect to resume full support in early November 2026. Thank you very much for your patience, if we are not able to reply to you until then. We greatly appreciate contributions and look forward to supporting you as soon as possible.
+We expect to resume full support by late October 2026. Thank you very much for your patience, if we are not able to reply to you until then. We greatly appreciate contributions and look forward to supporting you as soon as possible.
 
 To receive updates, subscribe to the WAI Translations mailing list by sending an e-mail to <public-wai-translations-request@w3.org> with subject: “subscribe”.
 

--- a/pages/about/translating/resources/subtitles.md
+++ b/pages/about/translating/resources/subtitles.md
@@ -43,6 +43,21 @@ This page guides you through the technical steps to create new subtitles and tra
 {% include toc.html type="end" %}
 {:/}
 
+{::nomarkdown}
+{% include box.html type="start" class="highlighted" %}
+{:/}
+**W3C staff temporarily has limited availability to support WAI translations.**
+
+We expect to resume full support in early November 2026. Thank you very much for your patience, if we are not able to reply to you until then. We greatly appreciate contributions and look forward to supporting you as soon as possible.
+
+To receive updates, subscribe to the WAI Translations mailing list by sending an e-mail to <public-wai-translations-request@w3.org> with subject: “subscribe”.
+
+For time-sensitive requests, contact <wai@w3.org>.
+
+{::nomarkdown}
+{% include box.html type="end" %}
+{:/}
+
 ## Overview
 
 There are 4 steps to create new subtitles or video descriptions in a new language:

--- a/pages/about/translating/resources/subtitles.md
+++ b/pages/about/translating/resources/subtitles.md
@@ -48,7 +48,7 @@ This page guides you through the technical steps to create new subtitles and tra
 {:/}
 **W3C staff temporarily has limited availability to support WAI translations.**
 
-We expect to resume full support in early November 2026. Thank you very much for your patience, if we are not able to reply to you until then. We greatly appreciate contributions and look forward to supporting you as soon as possible.
+We expect to resume full support by late October 2026. Thank you very much for your patience, if we are not able to reply to you until then. We greatly appreciate contributions and look forward to supporting you as soon as possible.
 
 To receive updates, subscribe to the WAI Translations mailing list by sending an e-mail to <public-wai-translations-request@w3.org> with subject: “subscribe”.
 

--- a/pages/about/translating/resources/technical-steps.md
+++ b/pages/about/translating/resources/technical-steps.md
@@ -51,7 +51,7 @@ For instructions on translating the Web Content Accessibility Guidelines (WCAG),
 {:/}
 **W3C staff temporarily has limited availability to support WAI translations.**
 
-We expect to resume full support in early November 2026. Thank you very much for your patience, if we are not able to reply to you until then. We greatly appreciate contributions and look forward to supporting you as soon as possible.
+We expect to resume full support by late October 2026. Thank you very much for your patience, if we are not able to reply to you until then. We greatly appreciate contributions and look forward to supporting you as soon as possible.
 
 To receive updates, subscribe to the WAI Translations mailing list by sending an e-mail to <public-wai-translations-request@w3.org> with subject: “subscribe”.
 

--- a/pages/about/translating/resources/technical-steps.md
+++ b/pages/about/translating/resources/technical-steps.md
@@ -46,6 +46,21 @@ For instructions on translating the Web Content Accessibility Guidelines (WCAG),
 {% include toc.html type="end" %}
 {:/}
 
+{::nomarkdown}
+{% include box.html type="start" class="highlighted" %}
+{:/}
+**W3C staff temporarily has limited availability to support WAI translations.**
+
+We expect to resume full support in early November 2026. Thank you very much for your patience, if we are not able to reply to you until then. We greatly appreciate contributions and look forward to supporting you as soon as possible.
+
+To receive updates, subscribe to the WAI Translations mailing list by sending an e-mail to <public-wai-translations-request@w3.org> with subject: “subscribe”.
+
+For time-sensitive requests, contact <wai@w3.org>.
+
+{::nomarkdown}
+{% include box.html type="end" %}
+{:/}
+
 ## Overview
 
 There are 4 main technical steps to create a new WAI resource translation:

--- a/pages/about/translating/resources/using-github.md
+++ b/pages/about/translating/resources/using-github.md
@@ -52,6 +52,21 @@ This page guide you through the steps to translate WAI resources using GitHub.
 {% include toc.html type="end" %}
 {:/}
 
+{::nomarkdown}
+{% include box.html type="start" class="highlighted" %}
+{:/}
+**W3C staff temporarily has limited availability to support WAI translations.**
+
+We expect to resume full support in early November 2026. Thank you very much for your patience, if we are not able to reply to you until then. We greatly appreciate contributions and look forward to supporting you as soon as possible.
+
+To receive updates, subscribe to the WAI Translations mailing list by sending an e-mail to <public-wai-translations-request@w3.org> with subject: “subscribe”.
+
+For time-sensitive requests, contact <wai@w3.org>.
+
+{::nomarkdown}
+{% include box.html type="end" %}
+{:/}
+
 {% include showhidebutton.html showtext="Show all screenshots" hidetext="Hide all screenshots" target=".screenshot" %}
 
 ## Initial step: Declare your intent

--- a/pages/about/translating/resources/using-github.md
+++ b/pages/about/translating/resources/using-github.md
@@ -57,7 +57,7 @@ This page guide you through the steps to translate WAI resources using GitHub.
 {:/}
 **W3C staff temporarily has limited availability to support WAI translations.**
 
-We expect to resume full support in early November 2026. Thank you very much for your patience, if we are not able to reply to you until then. We greatly appreciate contributions and look forward to supporting you as soon as possible.
+We expect to resume full support by late October 2026. Thank you very much for your patience, if we are not able to reply to you until then. We greatly appreciate contributions and look forward to supporting you as soon as possible.
 
 To receive updates, subscribe to the WAI Translations mailing list by sending an e-mail to <public-wai-translations-request@w3.org> with subject: “subscribe”.
 

--- a/pages/about/translating/reviewing.md
+++ b/pages/about/translating/reviewing.md
@@ -50,6 +50,21 @@ This page explains how you can participate in reviewing translations of Web Acce
 {% include toc.html type="end" %}
 {:/}
 
+{::nomarkdown}
+{% include box.html type="start" class="highlighted" %}
+{:/}
+**W3C staff temporarily has limited availability to support WAI translations.**
+
+We expect to resume full support in early November 2026. Thank you very much for your patience, if we are not able to reply to you until then. We greatly appreciate contributions and look forward to supporting you as soon as possible.
+
+To receive updates, subscribe to the WAI Translations mailing list by sending an e-mail to <public-wai-translations-request@w3.org> with subject: “subscribe”.
+
+For time-sensitive requests, contact <wai@w3.org>.
+
+{::nomarkdown}
+{% include box.html type="end" %}
+{:/}
+
 ## Overview
 
 The W3C Web Accessibility Initiative (WAI) welcomes contributions to review volunteer translations before they are published on the WAI website.

--- a/pages/about/translating/reviewing.md
+++ b/pages/about/translating/reviewing.md
@@ -55,7 +55,7 @@ This page explains how you can participate in reviewing translations of Web Acce
 {:/}
 **W3C staff temporarily has limited availability to support WAI translations.**
 
-We expect to resume full support in early November 2026. Thank you very much for your patience, if we are not able to reply to you until then. We greatly appreciate contributions and look forward to supporting you as soon as possible.
+We expect to resume full support by late October 2026. Thank you very much for your patience, if we are not able to reply to you until then. We greatly appreciate contributions and look forward to supporting you as soon as possible.
 
 To receive updates, subscribe to the WAI Translations mailing list by sending an e-mail to <public-wai-translations-request@w3.org> with subject: “subscribe”.
 


### PR DESCRIPTION
Add information about staff having limited availability to support translations until early November.

To do:
- [x] Before publication, check if the date needs update

<!--Describe the pull request below.-->


<!--If your PR has a primary page for review, set an entry path.
    Add a relative path next to `@netlify` below.-->

@netlify /about/translating/resources