### PR TITLE
Exclude resource submodules from dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,6 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - "submodules"
+    cooldown:
+      exclude:
+        - "_external/resources/*"


### PR DESCRIPTION
<!--Describe the pull request below.-->
Since 14 July 2026, Dependabot waits for at least three days before opening a new version update pull request. See [GitHub Changelog post](https://github.blog/changelog/2026-07-14-dependabot-version-updates-introduce-default-package-cooldown/).

This currently prevent us from updating some resources soon after PRs are merged in the submodule repositories.
This PR excludes resource submodules from cooldown settings.

<!--If your PR has a primary page for review, set an entry path.
    Add a relative path next to `@netlify` below.-->

@netlify /