### PR TITLE
Update workflows

### DIFF
--- a/.github/workflows/add-resource.yml
+++ b/.github/workflows/add-resource.yml
@@ -10,11 +10,12 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
     - name: Adding resource submodule
       run: |
         [ -d _external/resources/$WAI_NEW_RESOURCE ] && echo "Resource $WAI_NEW_RESOURCE exists" && exit 1
@@ -30,7 +31,7 @@ jobs:
       env:
         WAI_NEW_RESOURCE: ${{ github.event.inputs.resource }}
     - name: Commit changed files
-      uses: stefanzweifel/git-auto-commit-action@v4
+      uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d #v7.2.0
       with:
         commit_message: Apply automatic changes
   

--- a/.github/workflows/build-only.yml
+++ b/.github/workflows/build-only.yml
@@ -5,19 +5,17 @@ on:
   
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     permissions:
-      contents: write
+      contents: read
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
       with:
         submodules: true
         fetch-depth: 0
     - name: Set up Ruby 3.4.8
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b #v1.321.0
       with:
         ruby-version: 3.4.8
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,19 +6,17 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     permissions:
       contents: write
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
       with:
         submodules: true
         fetch-depth: 0
     - name: Set up Ruby 3.4.8
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b #v1.321.0
       with:
         ruby-version: '3.4.8' # matches Netlify ruby version
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
@@ -30,16 +28,16 @@ jobs:
       run: |
         find ./_site -type f | sed 's,^\.\/_site,,' | sort > ./_site/manifest.txt
     - name: Publish to gh-pages
-      uses: peaceiris/actions-gh-pages@v4
+      uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 #v4.1.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: _site
     - name: Zip Files
-      uses: montudor/action-zip@v1
+      uses: montudor/action-zip@0852c26906e00f8a315c704958823928d8018b28 #v1.0.0
       with:
         args: zip -r build.zip ./_site
     - name: Upload zip file to release
-      uses: svenstaro/upload-release-action@v2
+      uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de #v2.11.5
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
         file: build.zip
@@ -50,7 +48,7 @@ jobs:
       run: sleep 90s
       shell: bash
     - name: Update URL mapping on W3C site
-      uses: fjogeleit/http-request-action@v2
+      uses: fjogeleit/http-request-action@f98bb26551cd1af7d3eb2674578a80754ece88db #v2.0.1
       with:
         url: 'https://www.w3.org/services/update-wai-map'
         method: 'POST'

--- a/.github/workflows/label-issues.yml
+++ b/.github/workflows/label-issues.yml
@@ -11,7 +11,7 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-      - uses: github/issue-labeler@v3.4
+      - uses: github/issue-labeler@c1b0f9f52a63158c4adc09425e858e87b32e9685 #v3.4
         with:
           configuration-path: .github/labeler.yml
           enable-versioned-regex: 0

--- a/.github/workflows/mapsite.yml
+++ b/.github/workflows/mapsite.yml
@@ -2,15 +2,16 @@ name: mapsite
 
 on:
   workflow_dispatch
-  
+
+permissions:
+  contents: read
+
 jobs:
   map:
-
     runs-on: ubuntu-latest
-
     steps:
     - name: Update URL mapping on W3C site
-      uses: fjogeleit/http-request-action@v2
+      uses: fjogeleit/http-request-action@f98bb26551cd1af7d3eb2674578a80754ece88db #v2.0.1
       with:
         url: 'https://www.w3.org/services/update-wai-map'
         method: 'POST'

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -1,5 +1,5 @@
-# Warning this hides checkouts from the Github commits view
-# So unless you record a latter ref you will not be able to revert to the pre rollback state
+# Warning this hides checkouts from the GitHub commits view
+# So unless you record a latter ref you will not be able to revert to the pre-rollback state
 
 name: Rollback Website
 
@@ -15,14 +15,15 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
     - name: Check confirmation
       run: |
         test "yes" == "${{ github.event.inputs.areYouSure }}"
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
       with:
         ref: gh-pages
         fetch-depth: 10
@@ -31,7 +32,7 @@ jobs:
         git reset --hard ${{ github.event.inputs.targetRef }}
         git push -f
     - name: Update URL mapping on W3C site
-      uses: fjogeleit/http-request-action@v2
+      uses: fjogeleit/http-request-action@f98bb26551cd1af7d3eb2674578a80754ece88db #v2.0.1
       with:
         url: 'https://www.w3.org/services/update-wai-map'
         method: 'POST'


### PR DESCRIPTION
This PR:
- pins actions to a full-length commit SHA, following GitHub's recommendations
- bumps `checkout` from v6 to v7.0.1
- bumps `git-auto-commit-action` from v4 to v7.2.0
- sets more specific permissions

All actions were tested successfully in forks.