### PR TITLE
Escape | to avoid kramdown parsing line as a table

### DIFF
--- a/pages/about/update.md
+++ b/pages/about/update.md
@@ -190,7 +190,7 @@ To learn about contributing to W3C WAI accessibility work generally, **see [[Par
 
 W3C greatly appreciates the support WAI receives from contributors committed to making digital technology accessible. Sponsorships, donations, and grants enable WAI to bring together a unique collaboration of industry, government, research, and people with disabilities in a cooperative effort to improve digital accessibility for disabled people.
 
-**We invite organizations and individuals to support WAI financially. Please see [Support us | W3C](https://www.w3.org/support-us/) and let us know if you would like more information on specifically supporting W3C accessibility work.**
+**We invite organizations and individuals to support WAI financially. Please see [Support us \| W3C](https://www.w3.org/support-us/) and let us know if you would like more information on specifically supporting W3C accessibility work.**
 
 {% include_cached excol.html type="start" id="changelog" %}
 


### PR DESCRIPTION
<!--Describe the pull request below.-->

This fixes an issue in the "Support WAI" section added in #2270. Apparently, Kramdown mis-parsed the `|` character added within a link, treating it as a table cell separator. This was admittedly unexpected, given that there are no `|` characters at the start/end of the line to go along with it, which is typically how tables are designated in Markdown.

cc @shawna-slh FYI; she has limited availability today, so I will go ahead with merging and deploying this fix once I verify the preview (I've already verified locally).

<!--If your PR has a primary page for review, set an entry path.
    Add a relative path next to `@netlify` below.-->

@netlify /update/